### PR TITLE
Moved pywren runtime inside dockerfile

### DIFF
--- a/pywren_ibm_cloud/compute/backends/openwhisk/openwhisk.py
+++ b/pywren_ibm_cloud/compute/backends/openwhisk/openwhisk.py
@@ -118,13 +118,19 @@ class OpenWhiskBackend:
         self.cf_client.create_package(self.package)
         action_name = self._format_action_name(docker_image_name, memory)
 
-        create_function_handler_zip(openwhisk_config.FH_ZIP_LOCATION, '__main__.py', __file__)
+        # check if docker image already has pywren packages preinstalled
+        action_dir_contents = runtime_meta['action_dir_contents']
+        if '__main__.py' in action_dir_contents and 'pywren_ibm_cloud' in action_dir_contents:
+            self.cf_client.create_action(self.package, action_name, docker_image_name, code=None,
+                                     memory=memory, is_binary=False, timeout=timeout*1000)
+        else:
+            create_function_handler_zip(openwhisk_config.FH_ZIP_LOCATION, '__main__.py', __file__)
 
-        with open(openwhisk_config.FH_ZIP_LOCATION, "rb") as action_zip:
-            action_bin = action_zip.read()
-        self.cf_client.create_action(self.package, action_name, docker_image_name, code=action_bin,
+            with open(openwhisk_config.FH_ZIP_LOCATION, "rb") as action_zip:
+                action_bin = action_zip.read()
+            self.cf_client.create_action(self.package, action_name, docker_image_name, code=action_bin,
                                      memory=memory, is_binary=True, timeout=timeout*1000)
-        self._delete_function_handler_zip()
+            self._delete_function_handler_zip()
         return runtime_meta
 
     def delete_runtime(self, docker_image_name, memory):
@@ -195,6 +201,7 @@ class OpenWhiskBackend:
         action_code = """
             import sys
             import pkgutil
+            from os import listdir
 
             def main(args):
                 print("Extracting preinstalled Python modules...")
@@ -203,6 +210,8 @@ class OpenWhiskBackend:
                 runtime_meta["preinstalls"] = [entry for entry in sorted([[mod, is_pkg] for _, mod, is_pkg in mods])]
                 python_version = sys.version_info
                 runtime_meta["python_ver"] = str(python_version[0])+"."+str(python_version[1])
+                action_dir_contents = listdir("/action")
+                runtime_meta["action_dir_contents"] = action_dir_contents
                 print("Done!")
                 return runtime_meta
             """

--- a/pywren_ibm_cloud/libs/openwhisk/client.py
+++ b/pywren_ibm_cloud/libs/openwhisk/client.py
@@ -86,7 +86,8 @@ class OpenWhiskClient:
         if kind == 'blackbox':
             cfexec['image'] = image_name
         cfexec['binary'] = is_binary
-        cfexec['code'] = base64.b64encode(code).decode("utf-8") if is_binary else code
+        if code:
+            cfexec['code'] = base64.b64encode(code).decode("utf-8") if is_binary else code
         data['exec'] = cfexec
 
         logger.debug('I am about to create a new cloud function action: {}'.format(action_name))

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -80,6 +80,13 @@ pw = pywren.ibm_cf_executor(runtime_memory=512)
 
     *NOTE: In this previous example we built a Docker image based on Python 3.7, this means that now we also need Python 3.7 in the client machine.*
 
+    Using [Dockerfile.codeless](ibm_cf/Dockerfile.codeless) for the runtime may improve overall calculation times. The runtime already contains pywren preinstalled to optimise initialization times which may be valuable in some use-cases.
+
+        $ docker build -f runtime/ibm_cf/Dockerfile.codeless -t kpavel/pywren-codeless-runtime-3.7:0.1
+        $ pywren-ibm-cloud runtime build kpavel/pywren-codeless-runtime-3.7:0.1
+
+    Currently this runtime supported for ibm-cf and openwhisk only.
+
 2. **Use an already built runtime from a public repository**
 
     Maybe someone already built a Docker image with all the packages you need, and put it in a public repository.
@@ -152,3 +159,4 @@ pw = pywren.ibm_cf_executor(runtime_memory=512)
      You can clean everything related to PyWren, such as all deployed runtimes and cache information, and start from scratch by simply running the next command (Configuration is not deleted):
 
         $ pywren-ibm-cloud clean
+

--- a/runtime/ibm_cf/Dockerfile.codeless
+++ b/runtime/ibm_cf/Dockerfile.codeless
@@ -1,0 +1,55 @@
+# Based on: https://github.com/ibm-functions/runtime-python/tree/master/python3.7
+FROM python:3.7-slim-buster
+
+ENV FLASK_PROXY_PORT 8080
+
+RUN apt-get update \
+    # add some packages required for the pip install
+    && apt-get install -y \
+        gcc \
+        zlib1g-dev \
+        libxslt-dev \
+        libxml2-dev \
+        zip \
+        unzip \
+    # cleanup package lists, they are not used anymore in this image
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-cache search linux-headers-generic
+
+RUN pip install --upgrade pip setuptools six \
+    && pip install --no-cache-dir \
+        simplejson==3.16.0 \
+        httplib2==0.13.0 \
+        kafka_python==1.4.6 \
+        lxml==4.3.1 \
+        python-dateutil==2.8.0 \
+        pika==0.13.1 \
+        flask==1.1.1 \
+        gevent==1.4.0 \
+        ibm-cos-sdk==2.6.0 \
+        redis==3.3.8 \
+        requests==2.22.0 \
+        numpy==1.17.2
+
+# create action working directory
+RUN mkdir -p /action \
+    && mkdir -p /actionProxy \
+    && mkdir -p /pythonAction
+
+ADD https://raw.githubusercontent.com/apache/openwhisk-runtime-docker/dockerskeleton%401.14.0/core/actionProxy/actionproxy.py /actionProxy/actionproxy.py
+ADD https://raw.githubusercontent.com/apache/openwhisk-runtime-python/3%401.14.0/core/pythonAction/pythonrunner.py /pythonAction/pythonrunner.py
+
+ADD runtime/ibm_cf/codelessrunner.py /pythonAction/codelessrunner.py
+
+# download the latest pywren code and add it to the docker image
+RUN apt update \
+    && apt install -y wget \
+    && wget -O tmp.zip https://github.com/pywren/pywren-ibm-cloud/archive/master.zip \
+    && unzip tmp.zip pywren-ibm-cloud-master/pywren_ibm_cloud/* \
+    && cp pywren-ibm-cloud-master/pywren_ibm_cloud/compute/backends/ibm_cf/entry_point.py /action/__main__.py \
+    && mv pywren-ibm-cloud-master/pywren_ibm_cloud /action/ \
+    && rm tmp.zip \
+    && rm -r pywren-ibm-cloud-master
+
+# run codelessrunner.py
+CMD ["/bin/bash", "-c", "cd /pythonAction && python -u codelessrunner.py"]

--- a/runtime/ibm_cf/codelessrunner.py
+++ b/runtime/ibm_cf/codelessrunner.py
@@ -1,0 +1,87 @@
+"""Executable Python script for running Python actions.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
+import os
+import sys
+import codecs
+import traceback
+sys.path.append('../actionProxy')
+from actionproxy import ActionRunner, main, setRunner
+from pythonrunner import PythonRunner 
+
+class CodelessPythonRunner(PythonRunner):
+
+    def init(self, message):
+        binary = message['binary'] if 'binary' in message else False
+
+        if binary or 'code' in message:
+            return super(CodelessPythonRunner, self).init(message)
+
+        try:
+            # build the source
+            if self.build(message) is False:
+                return False
+        except Exception:
+            return False
+        # verify the binary exists and is executable
+        return self.verify()
+
+    def build(self, message):
+        code = None
+        if 'code' in message:
+            binary = message['binary'] if 'binary' in message else False
+            if not binary:
+                code = message['code']
+                filename = 'action'
+
+        if not code and os.path.isfile(self.source):
+            with codecs.open(self.source, 'r', 'utf-8') as m:
+                code = m.read()
+            workdir = os.path.dirname(self.source)
+            sys.path.insert(0, workdir)
+            os.chdir(workdir)
+
+        try:
+            filename = os.path.basename(self.source)
+
+            if 'main' in message:
+                self.mainFn = message['main']
+
+            self.fn = compile(code, filename=filename, mode='exec')
+            # if the directory 'virtualenv' is extracted out of a zip file
+            path_to_virtualenv = os.path.dirname(self.source) + '/virtualenv'
+            if os.path.isdir(path_to_virtualenv):
+                # activate the virtualenv using activate_this.py contained in the virtualenv
+                activate_this_file = path_to_virtualenv + '/bin/activate_this.py'
+                if os.path.exists(activate_this_file):
+                    with open(activate_this_file) as f:
+                        code = compile(f.read(), activate_this_file, 'exec')
+                        exec(code, dict(__file__=activate_this_file))
+                else:
+                    sys.stderr.write('Invalid virtualenv. Zip file does not include /virtualenv/bin/' + os.path.basename(activate_this_file) + '\n')
+                    return False
+            exec(self.fn, self.global_context)
+            return True
+        except Exception:
+            traceback.print_exc(file=sys.stderr, limit=0)
+            return False
+
+if __name__ == '__main__':
+    setRunner(CodelessPythonRunner())
+    main()


### PR DESCRIPTION
Currently pywren runtime code injected in action containers during container initialization. This PR provides option to avoid it by packaging pywren code inside Docker image.

Changes:
codelessrunner.py - extends pythonrunner and adds support for codeless python action
Dockerfile.codeless - provides base docker image for pywren runtime
ibm_cf.py and openwhisk.py - check that pywren runtime code and __main__.py already exist in docker image. If exist  - create action without injecting pywren code archive in the action


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

