### PR TITLE
Remove unnecessary enum34 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Click', 'pandas', 'PyYAML', 'python-dateutil',
-        'pika==0.13.1', 'enum34', 'glob2', 'tqdm', 'lxml',
+        'pika==0.13.1', 'glob2', 'tqdm', 'lxml',
         'tblib', 'docker', 'requests', 'seaborn', 'paramiko',
         'matplotlib', 'kubernetes', 'ibm-cos-sdk', 'gcsfs',
         'aliyun-fc2', 'oss2',


### PR DESCRIPTION
Enum34 is a compatibility library to allow Python <= 3.3 to use the `enum` library that is included with Python >= 3.4. Lithops now [requires Python >= 3.5](https://github.com/lithops-cloud/lithops/blob/master/setup.py#L56), so the compatibility library is no longer needed. Furthermore, it can create issues with pip, because enum34 actually overrides the native enum library and doesn't include newer features from Python 3.6 such as `enum.IntFlag`.


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

