### PR TITLE
Add support in monitoring from remote

### DIFF
--- a/lithops/storage/utils.py
+++ b/lithops/storage/utils.py
@@ -26,6 +26,7 @@ import textwrap
 logger = logging.getLogger(__name__)
 
 
+remote_futures_key_suffix = "remote_futures.pickle"
 func_key_suffix = "func.pickle"
 agg_data_key_suffix = "aggdata.pickle"
 data_key_suffix = "data.pickle"
@@ -115,6 +116,11 @@ def delete_cloudobject(co_to_clean, storage_config):
 
     cmdstr = '{} -c "{}"'.format(sys.executable, textwrap.dedent(script))
     os.popen(cmdstr)
+
+
+def create_remote_futures_key(prefix, executor_id, job_id):
+    remote_futures_key = '/'.join([prefix, executor_id, job_id, remote_futures_key_suffix])
+    return remote_futures_key
 
 
 def create_func_key(prefix, executor_id, job_id):

--- a/lithops/utils.py
+++ b/lithops/utils.py
@@ -51,6 +51,15 @@ def create_executor_id(lenght=6):
     return '{}/{}'.format(session_id, exec_num)
 
 
+def create_remote_monitor_id(executor_id, job_id):
+    return '-'.join([executor_id, job_id])
+
+
+def extract_data_from_remote_monitor_id(remote_monitor_id):
+    executor_id, job_id = remote_monitor_id.split('-')
+    return executor_id, job_id
+
+
 def create_rabbitmq_resources(rabbit_amqp_url, executor_id, job_id):
     """
     Creates RabbitMQ queues and exchanges of a given job in a thread.


### PR DESCRIPTION
reviving #71 

This patch adds the argument "remote_monitor" for `call_async()`, `map()` and `map_reduce()` methods, and the argument "remote_monitor_id" for `wait()` and `get_result()` which enables monitoring futures from remote by a provided `remote_monitor_id`

The code stores the futures immediately after they created, and produces a dedicated `remote_monitor_id` which composed by the executor id and the job id. With the provided `remote_monitor_id`, the `wait()` method downloads the corresponding futures from storage and monitors as usual.

example invoking function for monitoring in remote:
```python
import lithops

def hello(name):
    return 'Hello {}!'.format(name)

ex = lithops.function_executor()
ex.call_async(hello, 'World', remote_monitor=True)
```

example `remote_monitor_id` output:
```
ExecutorID b07c99/0 | JobID A000 - Initialized futures for monitoring in remote - RemoteMonitorID: b07c99/0-A000
```

example `remote_monitor_id` usage:
```python
import lithops

ex = lithops.function_executor()
print(ex.get_result(remote_monitor_id='b07c99/0-A000'))
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

