### PR TITLE
Fixing crashing StandaloneBackend constructor bug

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -30,7 +30,8 @@ class IBMVPCInstanceClient:
         iam_api_key = self.config.get('iam_api_key')
         token = self.config.get('token', None)
         token_expiry_time = self.config.get('token_expiry_time', None)
-        self.iam_token_manager = IBMIAMTokenManager(iam_api_key, token, token_expiry_time)
+        api_key_type = 'IAM'
+        self.iam_token_manager = IBMIAMTokenManager(iam_api_key, api_key_type, token, token_expiry_time)
 
         headers = {'content-type': 'application/json'}
         default_user_agent = self.session.headers['User-Agent']


### PR DESCRIPTION
Currently the StandaloneBackend constructor is crashing on attempt to instantiate IBMIAMTokenManager with wrong signature
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

