### PR TITLE
Avoid syntax warning on Python >= 3.8

### DIFF
--- a/lithops/multiprocessing/managers.py
+++ b/lithops/multiprocessing/managers.py
@@ -485,7 +485,7 @@ class DictProxy(BaseProxy):
 
     def update(self, *args, **kwargs):
         items = []
-        if args is not ():
+        if args != ():
             if len(args) > 1:
                 raise TypeError('update expected at most'
                     ' 1 arguments, got {}'.format(len(args)))


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8` or `python3.9`
```
>>> () is ()
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

Also, this logic seems a bit dangerous because this will only match if `args` is an __empty tuple__.  `[] != ()` so this will not match against an empty list, set, or other iterator.

I would have written: `if args:`



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

