### PR TITLE
Added init() to executors API

### DIFF
--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -545,6 +545,9 @@ class FunctionExecutor:
     def dismantle(self):
         self.compute_handler.dismantle()
 
+    def init(self):
+        self.compute_handler.init()
+
     def __exit__(self, exc_type, exc_value, traceback):
         self.invoker.stop()
         if self.data_cleaner:

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -211,16 +211,7 @@ class StandaloneHandler:
         Installs the proxy and extracts the runtime metadata and
         preinstalled modules
         """
-        if not self._is_backend_ready():
-            # The VM instance is stopped
-            init_time = time.time()
-            self.backend.start()
-            self._wait_backend_ready()
-            total_start_time = round(time.time()-init_time, 2)
-            logger.info('VM instance ready in {} seconds'.format(total_start_time))
-
-        self._setup_proxy()
-        self._wait_proxy_ready()
+        self.init()
 
         logger.info('Extracting runtime metadata information')
         payload = {'runtime': runtime}
@@ -243,6 +234,28 @@ class StandaloneHandler:
         Stop VM instance
         """
         self.backend.stop()
+
+    def init(self):
+        """
+        Start the VM instance and initialize runtime
+        """
+        # if not started, start the vm
+        if not self._is_backend_ready():
+            # The VM instance is stopped
+            init_time = time.time()
+            self.backend.start()
+            self._wait_backend_ready()
+            total_start_time = round(time.time()-init_time, 2)
+            logger.info('VM instance ready in {} seconds'.format(total_start_time))
+
+        # Not sure if mandatory, but sleep several seconds to let proxy server start
+        time.sleep(2)
+
+        # if proxy not started, install it
+        if not self._is_proxy_ready():
+            self._setup_proxy()
+
+        self._wait_proxy_ready()
 
     def clean(self):
         pass


### PR DESCRIPTION
starts the VM and validates that proxy service is running
in case proxy service not running installs it

currently supported for standalone executor only



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

