### PR TITLE
Fix map_iterdata description in map_reduce method.

### DIFF
--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -257,7 +257,7 @@ class FunctionExecutor:
         This method is executed all within CF.
 
         :param map_function: the function to map over the data
-        :param map_iterdata:  the function to reduce over the futures
+        :param map_iterdata:  An iterable of input data
         :param reduce_function:  the function to reduce over the futures
         :param extra_env: Additional environment variables for action environment. Default None.
         :param extra_args: Additional arguments to pass to function activation. Default None.


### PR DESCRIPTION
- Fix description of the argument `map_iterdata` in `executors map_reduce` method.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

