### PR TITLE
GCP Functions Backend create custom runtime update

### DIFF
--- a/lithops/config.py
+++ b/lithops/config.py
@@ -16,7 +16,6 @@
 #
 
 import os
-import sys
 import json
 import importlib
 import logging

--- a/lithops/invokers.py
+++ b/lithops/invokers.py
@@ -33,7 +33,7 @@ from lithops.config import extract_storage_config
 from lithops.utils import version_str, is_lithops_worker, is_unix_system
 from lithops.storage.utils import create_job_key
 from lithops.constants import LOGGER_LEVEL
-from lithops.util import PrometheusExporter
+from lithops.util.metrics import PrometheusExporter
 
 logger = logging.getLogger(__name__)
 

--- a/lithops/serverless/backends/gcp_functions/gcp_functions.py
+++ b/lithops/serverless/backends/gcp_functions/gcp_functions.py
@@ -241,6 +241,9 @@ class GCPFunctionsBackend:
         self.internal_storage.storage.delete_object(self.internal_storage.bucket, bin_name)
 
     def build_runtime(self, runtime_name, requirements_file):
+        if requirements_file is None:
+            raise Exception('Please provide a `requirements.txt` file with the necessary modules')
+        logger.info('Going to create runtime {} ({}) for GCP Functions...'.format(runtime_name, requirements_file))
         runtime_python_ver = 'python{}'.format(version_str(sys.version_info))
         if runtime_python_ver not in gcp_config.DEFAULT_RUNTIMES:
             raise Exception('Runtime {} is not available for GCP Functions, '
@@ -250,6 +253,8 @@ class GCPFunctionsBackend:
             requirements = req_file.read()
 
         self.internal_storage.put_data('/'.join([gcp_config.USER_RUNTIMES_PREFIX, runtime_name]), requirements)
+        logger.info('Ok - Created runtime {}'.format(runtime_name))
+        logger.info('Available runtimes: {}'.format(self._list_runtimes(default_runtimes=True)))
 
     def create_runtime(self, runtime_name, memory, timeout=60):
         logger.debug("Creating runtime {} - Memory: {} Timeout: {}".format(runtime_name, memory, timeout))

--- a/lithops/serverless/backends/ibm_cf/ibm_cf.py
+++ b/lithops/serverless/backends/ibm_cf/ibm_cf.py
@@ -25,7 +25,7 @@ from lithops.version import __version__
 from lithops.utils import is_lithops_worker
 from lithops.libs.openwhisk.client import OpenWhiskClient
 from lithops.utils import create_handler_zip
-from lithops.util import IBMTokenManager
+from lithops.util.ibm_token_manager import IBMTokenManager
 
 logger = logging.getLogger(__name__)
 

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -3,7 +3,7 @@ import logging
 import requests
 import time
 from lithops.version import __version__
-from lithops.util import IBMTokenManager
+from lithops.util.ibm_token_manager import IBMTokenManager
 
 logger = logging.getLogger(__name__)
 

--- a/lithops/storage/backends/ibm_cos/ibm_cos.py
+++ b/lithops/storage/backends/ibm_cos/ibm_cos.py
@@ -19,7 +19,7 @@ import ibm_boto3
 import ibm_botocore
 from lithops.storage.utils import StorageNoSuchKeyError
 from lithops.utils import sizeof_fmt, is_lithops_worker
-from lithops.util import IBMTokenManager
+from lithops.util.ibm_token_manager import IBMTokenManager
 
 logger = logging.getLogger(__name__)
 

--- a/lithops/util/__init__.py
+++ b/lithops/util/__init__.py
@@ -1,2 +1,0 @@
-from .ibm_token_manager import IBMTokenManager
-from .metrics import PrometheusExporter

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -24,6 +24,7 @@ import logging
 import inspect
 import requests
 import traceback
+import numpy as np
 from pydoc import locate
 from distutils.util import strtobool
 
@@ -33,7 +34,7 @@ from lithops.future import ResponseFuture
 from lithops.utils import sizeof_fmt, b64str_to_bytes, is_object_processing_function
 from lithops.utils import WrappedStreamingBodyPartition
 from lithops.constants import TEMP
-from lithops.util.metrics import PrometheusExporter
+from lithops.util import PrometheusExporter
 
 logger = logging.getLogger(__name__)
 

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -24,7 +24,6 @@ import logging
 import inspect
 import requests
 import traceback
-import numpy as np
 from pydoc import locate
 from distutils.util import strtobool
 
@@ -34,7 +33,7 @@ from lithops.future import ResponseFuture
 from lithops.utils import sizeof_fmt, b64str_to_bytes, is_object_processing_function
 from lithops.utils import WrappedStreamingBodyPartition
 from lithops.constants import TEMP
-from lithops.util import PrometheusExporter
+from lithops.util.metrics import PrometheusExporter
 
 logger = logging.getLogger(__name__)
 

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -34,7 +34,7 @@ from lithops.future import ResponseFuture
 from lithops.utils import sizeof_fmt, b64str_to_bytes, is_object_processing_function
 from lithops.utils import WrappedStreamingBodyPartition
 from lithops.constants import TEMP
-from lithops.util import PrometheusExporter
+from lithops.util.metrics import PrometheusExporter
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Improved logging when creating a new custom runtime for GCP Functions
- Refactor IBMTokenManager (removed from `utils.__init__.py` since IBMTokenManager imports `ibm_botocore` and this module is not available by default in other backends).
- Fixed CLI `lithops runtime create` command (Added `--mode` flag to select execution mode).
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

