### PR TITLE
Fixes failing runtime create bug

### DIFF
--- a/lithops/scripts/cli.py
+++ b/lithops/scripts/cli.py
@@ -199,6 +199,9 @@ def runtime(ctx):
 
 @runtime.command('create')
 @click.argument('name')
+@click.option('--mode', '-m', default=None,
+              type=click.Choice([SERVERLESS, LOCALHOST, STANDALONE], case_sensitive=True),
+              help='execution mode')
 @click.option('--backend', '-b', default=None, help='compute backend')
 @click.option('--memory', default=None, help='memory used by the runtime', type=int)
 @click.option('--timeout', default=None, help='runtime timeout', type=int)
@@ -208,7 +211,7 @@ def create(name, mode, backend, memory, timeout, config):
     setup_logger(logging.DEBUG)
     logger.info('Creating new lithops runtime: {}'.format(name))
 
-    mode = 'serverless'
+    mode = mode or get_mode(config)
     config_ow = {'lithops': {'mode': mode}}
     if backend:
         config_ow[mode] = {'backend': backend}

--- a/lithops/scripts/cli.py
+++ b/lithops/scripts/cli.py
@@ -199,19 +199,16 @@ def runtime(ctx):
 
 @runtime.command('create')
 @click.argument('name')
-@click.option('--mode', '-m', default=None,
-              type=click.Choice([SERVERLESS, LOCALHOST, STANDALONE], case_sensitive=True),
-              help='execution mode')
 @click.option('--backend', '-b', default=None, help='compute backend')
 @click.option('--memory', default=None, help='memory used by the runtime', type=int)
 @click.option('--timeout', default=None, help='runtime timeout', type=int)
 @click.option('--config', '-c', default=None, help='use json config file')
-def create(name, mode, backend, memory, timeout, config):
+def create(name, backend, memory, timeout, config):
     """ Create a serverless runtime """
     setup_logger(logging.DEBUG)
     logger.info('Creating new lithops runtime: {}'.format(name))
 
-    mode = mode or get_mode(config)
+    mode = SERVERLESS 
     config_ow = {'lithops': {'mode': mode}}
     if backend:
         config_ow[mode] = {'backend': backend}


### PR DESCRIPTION
The runtime create command currently broken. It is missing required 'mode' parameter. This PR resolves the issue
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

