### PR TITLE
Fix list_keys for IBM COS and AWS S3 storage backends

### DIFF
--- a/lithops/storage/backends/aws_s3/aws_s3.py
+++ b/lithops/storage/backends/aws_s3/aws_s3.py
@@ -19,7 +19,6 @@ import boto3
 import botocore
 from ...utils import StorageNoSuchKeyError
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -42,20 +41,20 @@ class S3Backend:
                                       endpoint_url=service_endpoint)
 
     def get_client(self):
-        '''
+        """
         Get boto3 client.
         :return: boto3 client
-        '''
+        """
         return self.s3_client
 
     def put_object(self, bucket_name, key, data):
-        '''
+        """
         Put an object in COS. Override the object if the key already exists.
         :param key: key of the object.
         :param data: data of the object
         :type data: str/bytes
         :return: None
-        '''
+        """
         try:
             res = self.s3_client.put_object(Bucket=bucket_name, Key=key, Body=data)
             status = 'OK' if res['ResponseMetadata']['HTTPStatusCode'] == 200 else 'Error'
@@ -70,12 +69,12 @@ class S3Backend:
                 raise e
 
     def get_object(self, bucket_name, key, stream=False, extra_get_args={}):
-        '''
+        """
         Get object from COS with a key. Throws StorageNoSuchKeyError if the given key does not exist.
         :param key: key of the object
         :return: Data of the object
         :rtype: str/bytes
-        '''
+        """
         try:
             r = self.s3_client.get_object(Bucket=bucket_name, Key=key, **extra_get_args)
             if stream:
@@ -90,12 +89,12 @@ class S3Backend:
                 raise e
 
     def head_object(self, bucket_name, key):
-        '''
+        """
         Head object from COS with a key. Throws StorageNoSuchKeyError if the given key does not exist.
         :param key: key of the object
         :return: Data of the object
         :rtype: str/bytes
-        '''
+        """
         try:
             metadata = self.s3_client.head_object(Bucket=bucket_name, Key=key)
             return metadata['ResponseMetadata']['HTTPHeaders']
@@ -106,32 +105,32 @@ class S3Backend:
                 raise e
 
     def delete_object(self, bucket_name, key):
-        '''
+        """
         Delete an object from storage.
         :param bucket: bucket name
         :param key: data key
-        '''
+        """
         return self.s3_client.delete_object(Bucket=bucket_name, Key=key)
 
     def delete_objects(self, bucket_name, key_list):
-        '''
+        """
         Delete a list of objects from storage.
         :param bucket: bucket name
         :param key_list: list of keys
-        '''
+        """
         result = []
         max_keys_num = 1000
         for i in range(0, len(key_list), max_keys_num):
             delete_keys = {'Objects': []}
-            delete_keys['Objects'] = [{'Key': k} for k in key_list[i:i+max_keys_num]]
+            delete_keys['Objects'] = [{'Key': k} for k in key_list[i:i + max_keys_num]]
             result.append(self.s3_client.delete_objects(Bucket=bucket_name, Delete=delete_keys))
         return result
 
     def bucket_exists(self, bucket_name):
-        '''
+        """
         Head bucket from COS with a name. Throws StorageNoSuchKeyError if the given bucket does not exist.
         :param bucket_name: name of the bucket
-        '''
+        """
         try:
             self.s3_client.head_bucket(Bucket=bucket_name)
         except botocore.exceptions.ClientError as e:
@@ -141,12 +140,12 @@ class S3Backend:
                 raise e
 
     def head_bucket(self, bucket_name):
-        '''
+        """
         Head bucket from COS with a name. Throws StorageNoSuchKeyError if the given bucket does not exist.
         :param bucket_name: name of the bucket
         :return: Metadata of the bucket
         :rtype: str/bytes
-        '''
+        """
         try:
             return self.s3_client.head_bucket(Bucket=bucket_name)
         except botocore.exceptions.ClientError as e:
@@ -156,13 +155,13 @@ class S3Backend:
                 raise e
 
     def list_objects(self, bucket_name, prefix=None):
-        '''
+        """
         Return a list of objects for the given bucket and prefix.
         :param bucket_name: Name of the bucket.
         :param prefix: Prefix to filter object names.
         :return: List of objects in bucket that match the given prefix.
         :rtype: list of str
-        '''
+        """
         try:
             prefix = '' if prefix is None else prefix
             paginator = self.s3_client.get_paginator('list_objects_v2')
@@ -182,17 +181,18 @@ class S3Backend:
                 raise e
 
     def list_keys(self, bucket_name, prefix=None):
-        '''
+        """
         Return a list of keys for the given prefix.
         :param bucket_name: Name of the bucket.
         :param prefix: Prefix to filter object names.
         :return: List of keys in bucket that match the given prefix.
         :rtype: list of str
-        '''
+        """
         try:
             prefix = '' if prefix is None else prefix
+            start_after = ('' or prefix) if prefix.endswith('/') else ''
             paginator = self.s3_client.get_paginator('list_objects_v2')
-            page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
+            page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix, StartAfter=start_after)
 
             key_list = []
             for page in page_iterator:

--- a/lithops/storage/backends/ibm_cos/ibm_cos.py
+++ b/lithops/storage/backends/ibm_cos/ibm_cos.py
@@ -267,8 +267,9 @@ class IBMCloudObjectStorageBackend:
         """
         try:
             prefix = '' if prefix is None else prefix
+            start_after = ('' or prefix) if prefix.endswith('/') else ''
             paginator = self.cos_client.get_paginator('list_objects_v2')
-            page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
+            page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix, StartAfter=start_after)
 
             key_list = []
             for page in page_iterator:


### PR DESCRIPTION
- Fix list_keys for IBM COS and AWS S3 storage backends: When `prefix == ''` it should return all keys. With this fix, now it does correctly (it didn't return any key before).
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

