### PR TITLE
Fix call to SSHClient.create_client

### DIFF
--- a/lithops/util/ssh_client.py
+++ b/lithops/util/ssh_client.py
@@ -27,7 +27,7 @@ class SSHClient():
         try:
             stdin, stdout, stderr = ssh_client.exec_command(cmd)
         except Exception:
-            ssh_client = self._create_client(ip_address, timeout=timeout, force=True)
+            ssh_client = self.create_client(ip_address, timeout)
             stdin, stdout, stderr = ssh_client.exec_command(cmd)
 
         out = None


### PR DESCRIPTION


I sometimes get stalls while starting an IBM VPC VM. This is what the logs looked like (Note: I added `print(ex)` to the exception handler in `StandaloneHandler._is_proxy_ready` so I could see why it was infinitely looping):
```
Lithops v2.2.11 init for IBM Virtual Private Cloud - Host: 149.81.167.108 - Region: eu-de
ExecutorID c27521-8 | JobID A000 - Selected Runtime: metaspace2020/metaspace-lithops:1.8.1 
ExecutorID c27521-8 | JobID A000 - Uploading function and data - Total: 656.0B
'SSHClient' object has no attribute '_create_client'
ExecutorID c27521-8 - Starting VM instance
'SSHClient' object has no attribute '_create_client'
'SSHClient' object has no attribute '_create_client'
'SSHClient' object has no attribute '_create_client'
'SSHClient' object has no attribute '_create_client'
'SSHClient' object has no attribute '_create_client'
'SSHClient' object has no attribute '_create_client'
'SSHClient' object has no attribute '_create_client'
^CTraceback (most recent call last):
  File "/home/lachlan/miniconda3/envs/sm38/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3417, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-6-bd5209b1c242>", line 18, in <module>
    fs = executor.call_async(wait_a_minute, ())
  File "/home/lachlan/miniconda3/envs/sm38/lib/python3.8/site-packages/lithops/executors.py", line 184, in call_async
    futures = self.invoker.run(job)
  File "/home/lachlan/miniconda3/envs/sm38/lib/python3.8/site-packages/lithops/invokers.py", line 147, in run
    self.compute_handler.run_job(payload)
  File "/home/lachlan/miniconda3/envs/sm38/lib/python3.8/site-packages/lithops/standalone/standalone.py", line 220, in run_job
    self._wait_proxy_ready()
  File "/home/lachlan/miniconda3/envs/sm38/lib/python3.8/site-packages/lithops/standalone/standalone.py", line 155, in _wait_proxy_ready
    time.sleep(1)
KeyboardInterrupt
```

The only `_create_client` in the repository is the line in this PR. The change in this PR fixes the issue for me. It seems this block of code exists to reconnect to the VM if the connection cached in `global ssh_clients` is broken and fails the first `ssh_client.exec_command` call.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

