### PR TITLE
Localhost Storage fixes/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - [Core] Fixed Storage API error when no config is provided
 - [Core] Fixed expired IAM token in IBM CF during an execution
+- [Localhost] Fixed empty parent directory deletion when deleting objects
 
 ## [v2.2.13]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Core] Fixed Storage API error when no config is provided
 - [Core] Fixed expired IAM token in IBM CF during an execution
 - [Localhost] Fixed empty parent directory deletion when deleting objects
+- [Localhost] Made list_keys/list_objects behavior consistent with other backends 
 
 ## [v2.2.13]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - [Azure] Azure Functions backend upgraded
+- [Localhost] Support passing file-like objects to put_object
 
 ### Fixed
 - [Core] Fixed Storage API error when no config is provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - [Azure] Azure Functions backend upgraded
 - [Localhost] Support passing file-like objects to put_object
+- [Localhost] Support head_bucket and head_object storage operations
 
 ### Fixed
 - [Core] Fixed Storage API error when no config is provided

--- a/lithops/storage/backends/localhost/localhost.py
+++ b/lithops/storage/backends/localhost/localhost.py
@@ -184,27 +184,12 @@ class LocalhostStorageBackend:
         :rtype: list of str
         """
         obj_list = []
+        base_dir = os.path.join(LITHOPS_TEMP_DIR, bucket_name, '')
 
-        if prefix:
-            if prefix.endswith('/'):
-                root = os.path.join(LITHOPS_TEMP_DIR,
-                                    bucket_name,
-                                    prefix, '**')
-            else:
-                root = os.path.join(LITHOPS_TEMP_DIR,
-                                    bucket_name,
-                                    prefix+'*', '**')
-        else:
-            root = os.path.join(LITHOPS_TEMP_DIR,
-                                bucket_name, '**')
-
-        for file_name in glob.glob(root, recursive=True):
-            if os.path.isfile(file_name):
-                if file_name.endswith(prefix):
-                    continue
-                size = os.stat(file_name).st_size
-                base_dir = os.path.join(LITHOPS_TEMP_DIR, bucket_name, '')
-                obj_list.append({'Key': file_name.replace(base_dir, '').replace('\\', '/'), 'Size': size})
+        for key in self.list_keys(bucket_name, prefix):
+            file_name = os.path.join(base_dir, key)
+            size = os.stat(file_name).st_size
+            obj_list.append({'Key': key, 'Size': size})
 
         return obj_list
 
@@ -217,25 +202,22 @@ class LocalhostStorageBackend:
         :rtype: list of str
         """
         key_list = []
+        base_dir = os.path.join(LITHOPS_TEMP_DIR, bucket_name, '')
 
         if prefix:
             if prefix.endswith('/'):
-                root = os.path.join(LITHOPS_TEMP_DIR,
-                                    bucket_name,
-                                    prefix, '**')
+                roots = [os.path.join(base_dir, prefix, '**')]
             else:
-                root = os.path.join(LITHOPS_TEMP_DIR,
-                                    bucket_name,
-                                    prefix+'*', '**')
+                roots = [
+                    os.path.join(base_dir, prefix+'*'),
+                    os.path.join(base_dir, prefix+'*', '**'),
+                ]
         else:
-            root = os.path.join(LITHOPS_TEMP_DIR,
-                                bucket_name, '**')
+            roots = [os.path.join(base_dir, '**')]
 
-        for file_name in glob.iglob(root, recursive=True):
-            if os.path.isfile(file_name):
-                if file_name.endswith(prefix):
-                    continue
-                base_dir = os.path.join(LITHOPS_TEMP_DIR, bucket_name, '')
-                key_list.append(file_name.replace(base_dir, '').replace('\\', '/'))
+        for root in roots:
+            for file_name in glob.glob(root, recursive=True):
+                if os.path.isfile(file_name):
+                    key_list.append(file_name.replace(base_dir, '').replace('\\', '/'))
 
         return key_list

--- a/lithops/storage/backends/localhost/localhost.py
+++ b/lithops/storage/backends/localhost/localhost.py
@@ -114,10 +114,16 @@ class LocalhostStorageBackend:
         Head object from local filesystem with a key.
         Throws StorageNoSuchKeyError if the given key does not exist.
         :param key: key of the object
-        :return: Data of the object
-        :rtype: str/bytes
+        :return: metadata of the object
         """
-        pass
+        file_path = os.path.join(LITHOPS_TEMP_DIR, bucket_name, key)
+        if os.path.isfile(file_path):
+            # Imitate the COS/S3 response
+            return {
+                'content-length': str(os.stat(file_path).st_size)
+            }
+
+        raise StorageNoSuchKeyError(os.path.join(LITHOPS_TEMP_DIR, bucket_name), key)
 
     def delete_object(self, bucket_name, key):
         """
@@ -155,10 +161,11 @@ class LocalhostStorageBackend:
         Head localhost dir with a name.
         Throws StorageNoSuchKeyError if the given bucket does not exist.
         :param bucket_name: name of the bucket
-        :return: Metadata of the bucket
-        :rtype: str/bytes
         """
-        raise NotImplementedError
+        if os.path.isdir(os.path.join(LITHOPS_TEMP_DIR, bucket_name)):
+            return {}
+        else:
+            raise StorageNoSuchKeyError(os.path.join(LITHOPS_TEMP_DIR, bucket_name), '')
 
     def list_objects(self, bucket_name, prefix=None):
         """

--- a/lithops/storage/backends/localhost/localhost.py
+++ b/lithops/storage/backends/localhost/localhost.py
@@ -69,18 +69,19 @@ class LocalhostStorageBackend:
         :type data: str/bytes
         :return: None
         """
-        try:
-            data_type = type(data)
-            file_path = os.path.join(LITHOPS_TEMP_DIR, bucket_name, key)
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            if data_type == bytes:
-                with open(file_path, "wb") as f:
-                    f.write(data)
-            else:
-                with open(file_path, "w") as f:
-                    f.write(data)
-        except Exception as e:
-            raise(e)
+        data_type = type(data)
+        file_path = os.path.join(LITHOPS_TEMP_DIR, bucket_name, key)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+        if data_type == bytes:
+            with open(file_path, "wb") as f:
+                f.write(data)
+        elif hasattr(data, 'read'):
+            with open(file_path, "wb") as f:
+                shutil.copyfileobj(data, f, 1024*1024)
+        else:
+            with open(file_path, "w") as f:
+                f.write(data)
 
     def get_object(self, bucket_name, key, stream=False, extra_get_args={}):
         """

--- a/lithops/storage/backends/localhost/localhost.py
+++ b/lithops/storage/backends/localhost/localhost.py
@@ -131,12 +131,20 @@ class LocalhostStorageBackend:
         :param bucket: bucket name
         :param key: data key
         """
-        file_path = os.path.join(LITHOPS_TEMP_DIR, bucket_name, key)
+        base_dir = os.path.join(LITHOPS_TEMP_DIR, bucket_name, '')
+        file_path = os.path.join(base_dir, key)
         try:
-            file_dir = os.path.dirname(file_path)
             if os.path.exists(file_path):
                 os.remove(file_path)
-            shutil.rmtree(file_dir, ignore_errors=True)
+
+            # Recursively clean up empty parent directories, but not the bucket itself
+            parent_dir = os.path.dirname(file_path)
+            while parent_dir.startswith(base_dir) and len(parent_dir) > len(base_dir):
+                try:
+                    os.rmdir(parent_dir)
+                    parent_dir = os.path.abspath(os.path.join(parent_dir, '..'))
+                except OSError:
+                    break
         except Exception:
             pass
 


### PR DESCRIPTION
* Support passing file-like objects to `put_object` for streaming uploads
    * The `1024*1024` parameter to `shutil.copyfileobj(data, f, 1024*1024)` determines chunk size. It may warrant further tuning, but I know that the default value (16kB) definitely causes performance issues.
* Support `head_bucket` and `head_object` functions
* Fixed empty parent directory deletion when deleting objects. The previous behavior was to delete a single parent directory, even if it was non-empty. Now it can delete multiple layers of empty directories, but only if they are actually empty.
* Made `list_keys`/`list_objects` behavior consistent with COS-style backends. 
    * Passing `prefix='foo'` will now match a files called `foo`, `foo0`, `foo123`, etc.
    * Changed `list_keys` to not use case-insensitive `glob`. I also changed `list_objects` to re-use `list_keys` so that their implementation doesn't diverge like this again.
    * Removed this code. I'm not sure what it was intended for, but it prevented `prefix='foo'` from matching `foo`.
        ```python
        if file_name.endswith(prefix):
            continue
        ```
* Added several tests to ensure Localhost and COS storage behavior was consistent
    * I found this test was broken before I even made any changes. I don't know what it does, so I haven't tried to fix it:
        ```
        ======================================================================
        FAIL: test_storage_handler (lithops.tests.TestLithops)
        ----------------------------------------------------------------------
        Traceback (most recent call last):
          File "/home/lachlan/dev/lithops/lithops/tests.py", line 377, in test_storage_handler
            self.assertEqual(result, self.__class__.cos_result_to_compare)
        AssertionError: 291131 != 291130
        ----------------------------------------------------------------------
        ```



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

