### PR TITLE
COS config load fix for ibm-vpc backend

### DIFF
--- a/lithops/storage/backends/ibm_cos/config.py
+++ b/lithops/storage/backends/ibm_cos/config.py
@@ -45,10 +45,6 @@ def load_config(config_data):
         if not config_data['ibm_cos']['private_endpoint'].startswith('http'):
             raise Exception('IBM COS Private Endpoint must start with http:// or https://')
 
-    elif config_data['lithops']['mode'] == 'standalone' \
-        and config_data['standalone']['backend'] == 'ibm_vpc':
-            pass
-
     elif 'private_endpoint' in config_data['ibm_cos']:
         del config_data['ibm_cos']['private_endpoint']
 


### PR DESCRIPTION
Currently the communication with COS fails in case ibm_vpc backend and private_endpoint present under ibm_cos config
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

