### PR TITLE
Provide ability to automatically create and delete VM instances

### DIFF
--- a/config/compute/ibm_vpc.md
+++ b/config/compute/ibm_vpc.md
@@ -80,6 +80,7 @@ The fastest way to find all the required keys is following:
 14. Set `delete_on_dismantle` to `True` in order to delete VM with all its resource on dismantle instead of stop 
 
 Your lithops config ibm_vpc section should look like:
+
     ```yaml
     ibm_vpc:
         endpoint    : <REGION_ENDPOINT>	    #endpoint    : <REGION_ENDPOINT>

--- a/config/compute/ibm_vpc.md
+++ b/config/compute/ibm_vpc.md
@@ -83,9 +83,9 @@ Your lithops config ibm_vpc section should look like:
 
     ```yaml
     ibm_vpc:
-        endpoint    : <REGION_ENDPOINT>	    #endpoint    : <REGION_ENDPOINT>
-        instance_id : <INSTANCE_ID>	    #instance_id : <INSTANCE_ID>  # Optional
-        ip_address  : <FLOATING_IP_ADDRESS>	    #ip_address  : <FLOATING_IP_ADDRESS> # Optional
+        endpoint    : <REGION_ENDPOINT>
+        instance_id : <INSTANCE_ID>	    # Optional
+        ip_address  : <FLOATING_IP_ADDRESS>	   # Optional
         security_group_id: <SECURITY_GROUP_ID>
         subnet_id: <SUBNET_ID>
         key_id: <PUBLIC_KEY_ID>

--- a/config/compute/ibm_vpc.md
+++ b/config/compute/ibm_vpc.md
@@ -52,9 +52,19 @@ $ lithops logs poll
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
 |ibm_vpc | endpoint | |yes | Endpoint of your subnet region |
-|ibm_vpc | instance_id | |yes | virtual server instance ID |
-|ibm_vpc | ip_address | |yes | Floatting IP address atached to your Vm instance|
+|ibm_vpc | instance_id | | no | virtual server instance ID |
+|ibm_vpc | ip_address | | no | Floatting IP address atached to your Vm instance|
 |ibm_vpc | version | | no | Use for specifying IBM VPC production application version date, it is recommended to configure it statically |
 |ibm_vpc | generation | 2 | no | Use for specifying IBM VPC environment compute generation, see [Comparing compute generations in VPC](https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-vpc-vpcoc) for additional information |
 |ibm_vpc | ssh_user | root |no | Username to access the VM |
 |ibm_vpc | ssh_key_filename | | no | Path to the ssh key file provided to create the VM. It will use the default path if not provided |
+|ibm_vpc | security_group_id | | yes | Security group id |
+|ibm_vpc | subnet_id | | yes | Subnet id |
+|ibm_vpc | key_id | | yes | Ssh public key id |
+|ibm_vpc | resource_group_id | | yes | Resource group id |
+|ibm_vpc | vpc_id | | yes | VPC id |
+|ibm_vpc | image_id | | yes | Virtual machine image id |
+|ibm_vpc | zone_name | | yes | Zone name |
+|ibm_vpc | volume_tier_name | | no | Virtual machine volume tier |
+|ibm_vpc | profile_name | | no | Virtual machine profile name |
+|ibm_vpc | delete_on_dismantle | | no | If True delete VM resource when dismantled |

--- a/config/compute/ibm_vpc.md
+++ b/config/compute/ibm_vpc.md
@@ -49,6 +49,54 @@ $ lithops logs poll
 
 #### Summary of configuration keys for IBM VPC
 
+The fastest way to find all the required keys is following:
+
+1. Login to IBM Cloud and open up your [dashboard](https://cloud.ibm.com/).
+
+2. Navigate to your [IBM VPC create instance](https://cloud.ibm.com/vpc-ext/provision/vs).
+
+3. On the left, fill all the parameters required for your new VM instance creation: name, resource group, location, image, ssh key and vpc
+
+4. On the right, click `Get sample API call`.
+
+5. Copy to clipboard the code from the `REST request: Creating a virtual server instance` dialog and paste to your favorite editor.
+
+6. Close the `Create instance` window without creating it.
+
+7. In the code, find `security_groups` section and paste its `id` value to the .lithops_config ibm_vpc section security_group_id key.
+
+8. Find `subnet` section and paste its `id` value to the .lithops_config ibm_vpc section subnet_id key.
+
+9. Find `keys` section and paste its `id` value to the .lithops_config ibm_vpc section key_id key.
+
+10. Find `resource_group` section and paste its `id` value to the .lithops_config ibm_vpc section resource_group_id key.
+
+11. Find `vpc` section and paste its `id` value to the .lithops_config ibm_vpc section vpc_id key.
+
+12. Find `image` section and paste its `id` value to the .lithops_config ibm_vpc section image_id key.
+
+13. Find `zone` section and paste its `name` value to the .lithops_config ibm_vpc section zone_name key.
+
+14. Set `delete_on_dismantle` to `True` in order to delete VM with all its resource on dismantle instead of stop 
+
+Your lithops config ibm_vpc section should look like:
+    ```yaml
+    ibm_vpc:
+        endpoint    : <REGION_ENDPOINT>	    #endpoint    : <REGION_ENDPOINT>
+        instance_id : <INSTANCE_ID>	    #instance_id : <INSTANCE_ID>  # Optional
+        ip_address  : <FLOATING_IP_ADDRESS>	    #ip_address  : <FLOATING_IP_ADDRESS> # Optional
+        security_group_id: <SECURITY_GROUP_ID>
+        subnet_id: <SUBNET_ID>
+        key_id: <PUBLIC_KEY_ID>
+        resource_group_id: <RESOURCE_GROUP_ID>
+        vpc_id: <VPC_ID>
+        image_id: <IMAGE_ID>
+        zone_name: <ZONE_NAME>
+        volume_tier_name: <VOLUME_TIER_NAME>  # Optional
+        profile_name: <PROFILE_NAME>  # Optional
+        delete_on_dismantle: False  # Optional
+    ```
+
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
 |ibm_vpc | endpoint | |yes | Endpoint of your subnet region |

--- a/config/compute/ibm_vpc.md
+++ b/config/compute/ibm_vpc.md
@@ -96,6 +96,36 @@ Your lithops config ibm_vpc section should look like:
         volume_tier_name: <VOLUME_TIER_NAME>  # Optional
         profile_name: <PROFILE_NAME>  # Optional
         delete_on_dismantle: False  # Optional
+
+
+    e.g. to automatically create VM instance from Ubuntu 20.04 image and delete it on dismantle
+    ibm_vpc:
+        endpoint: https://us-south.iaas.cloud.ibm.com
+        security_group_id: r006-2d3cc459-bb8b-4ec6-a5fb-28e60c9f7d7b
+        subnet_id: 0737-bbc80a8f-d46a-4cc6-8a5a-991daa5fc914
+        key_id: r006-14719c2a-80cf-4043-8018-fa22d4ce1337
+        resource_group_id: 8145289ddf7047ea93fd2835de391f43
+        vpc_id: r006-afdd7b5d-059f-413f-a319-c0a38ef46824
+        image_id: r006-988caa8b-7786-49c9-aea6-9553af2b1969
+        zone_name: us-south-3
+        volume_tier_name: 10iops-tier
+        profile_name: bx2-8x32
+        delete_on_dismantle: True
+    ```
+
+    and in the code call "create()" method:
+    ```python
+    import lithops
+
+    def hello(name):
+        return 'Hello {}!'.format(name)
+
+    if __name__ == '__main__':
+        fexec = lithops.StandaloneExecutor(log_level='DEBUG')
+
+        fexec.create()  #provisions vm instance in ibm vpc
+
+        fexec.call_async(hello, 'World')
     ```
 
 |Group|Key|Default|Mandatory|Additional info|

--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -45,12 +45,22 @@ lithops:
 
 #ibm_vpc:
     #endpoint    : <REGION_ENDPOINT>
-    #instance_id : <INSTANCE_ID>
+    #instance_id : <INSTANCE_ID>  # Optional
     #ip_address  : <FLOATING_IP_ADDRESS>
     #version     : <VPC_VERSION>
     #generation  : <VPC_GENERATION>
     #ssh_user    : <SSH_USERNAME>
     #ssh_key_filename: <SSH_PASSWORD>
+    #security_group_id: <SECURITY_GROUP_ID>
+    #subnet_id: <SUBNET_ID>
+    #key_id: <PUBLIC_KEY_ID>
+    #resource_group_id: <RESOURCE_GROUP_ID>
+    #vpc_id: <VPC_ID>
+    #image_id: <IMAGE_ID>
+    #zone_name: <ZONE_NAME>
+    #volume_tier_name: <VOLUME_TIER_NAME>  # Optional
+    #profile_name: <PROFILE_NAME>  # Optional
+    #delete_on_dismantle: False  # Optional
 
 #vm:
     #host: <IP_ADDRESS>

--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -628,3 +628,4 @@ class StandaloneExecutor(FunctionExecutor):
     def create(self):
         runtime_key, runtime_meta = self.compute_handler.create()
         self.internal_storage.put_runtime_meta(runtime_key, runtime_meta)
+

--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -552,9 +552,6 @@ class FunctionExecutor:
     def init(self):
         self.compute_handler.init()
 
-    def create(self):
-        self.compute_handler.create()
-
     def __exit__(self, exc_type, exc_value, traceback):
         self.invoker.stop()
 
@@ -627,3 +624,7 @@ class StandaloneExecutor(FunctionExecutor):
         super().__init__(mode=STANDALONE, config=config, runtime=runtime,
                          backend=backend, storage=storage, workers=workers,
                          rabbitmq_monitor=rabbitmq_monitor, log_level=log_level)
+
+    def create(self):
+        runtime_key, runtime_meta = self.compute_handler.create()
+        self.internal_storage.put_runtime_meta(runtime_key, runtime_meta)

--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -552,6 +552,9 @@ class FunctionExecutor:
     def init(self):
         self.compute_handler.init()
 
+    def create(self):
+        self.compute_handler.create()
+
     def __exit__(self, exc_type, exc_value, traceback):
         self.invoker.stop()
 

--- a/lithops/standalone/backends/ibm_vpc/config.py
+++ b/lithops/standalone/backends/ibm_vpc/config.py
@@ -1,5 +1,6 @@
 import datetime
 
+MANDATORY_PARAMETERS = ['endpoint', 'security_group_id', 'subnet_id', 'key_id', 'resource_group_id', 'vpc_id', 'image_id', 'zone_name']
 
 def load_config(config_data):
     section = 'ibm_vpc'
@@ -10,13 +11,10 @@ def load_config(config_data):
         msg = 'IBM IAM api key is mandatory in ibm section of the configuration'
         raise Exception(msg)
 
-    if 'endpoint' not in config_data[section]:
-        msg = 'endpoint is mandatory in {} section of the configuration'.format(section)
-        raise Exception(msg)
-
-    if 'instance_id' not in config_data[section]:
-        msg = 'instance_id is mandatory in {} section of the configuration'.format(section)
-        raise Exception(msg)
+    for param in MANDATORY_PARAMETERS:
+        if param not in config_data[section]:
+            msg = '{} is mandatory in {} section of the configuration'.format(param, section)
+            raise Exception(msg)
 
     if 'version' not in config_data:
         # it is not safe to use version as today() due to timezone differences. may fail at midnight. better use yesterday
@@ -25,3 +23,12 @@ def load_config(config_data):
 
     if 'generation' not in config_data:
         config_data[section]['generation'] = 2
+
+    if 'volume_tier_name' not in config_data[section]:
+        config_data[section]['volume_tier_name'] = '10iops-tier'
+
+    if 'profile_name' not in config_data[section]:
+        config_data[section]['profile_name'] = 'bx2-8x32'
+
+    if 'delete_on_dismantle' not in config_data[section]:
+        config_data[section]['delete_on_dismantle'] = False

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -167,14 +167,18 @@ class IBMVPCInstanceClient:
 
         return floating_ip
 
-    def _delete_instance(self, instance, floating_ip):
+    def delete(self, instance_id):
+        # delete floating ip
+        response = service.list_instance_network_interfaces(instance_id)
+        for nic in response.result['network_interfaces']:
+            if 'floating_ips' in nic:
+                for fip in nic['floating_ips']:
+                    service.delete_floating_ip(fip['id'])
+                    print("floating ip {} been deleted".format(floating_ip['address']))
+
         # delete vm instance
         self.service.delete_instance(instance['id'])
         print("instance {} been deleted".format(instance['name']))
-
-        # delete floating ip
-        self.service.delete_floating_ip(floating_ip['id'])
-        print("floating ip {} been deleted".format(floating_ip['address']))
 
     def start(self):
         logger.info("Starting VM instance")

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -188,21 +188,22 @@ class IBMVPCInstanceClient:
         logger.info("Creating VM instance")
 
         instance = self._create_instance()
-        floating_ip = self._create_and_attach_floating_ip(instance)
-        logger.debug("VM instance created successfully")
+        floating_ip = self._create_and_attach_floating_ip(instance)['address']
+        logger.debug("VM {} created successfully with floating IP {}".format(instance['name'], floating_ip))
 
         self.instance_id = instance['id']
         self.config['instance_id'] = instance['id']
         self.config['ip_address'] = floating_ip
 
-        return instance['id'], floating_ip['address']
+        return instance['id'], floating_ip
 
     def stop(self):
-        logger.info("Stopping VM instance")
         if self.config['lowcost']:
+            logger.info("Deleting VM instance")
             self._delete_instance()
             logger.debug("VM instance deleted successfully")
         else:
+            logger.info("Stopping VM instance")
             self.create_instance_action('stop')
             logger.debug("VM instance stopped successfully")
 

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -183,14 +183,16 @@ class IBMVPCInstanceClient:
 
     def create(self):
         logger.info("Creating VM instance")
-        
+
         instance = self._create_instance()
         floating_ip = self._create_and_attach_floating_ip(instance)
         logger.debug("VM instance created successfully")
+
         self.instance_id = instance['id']
         self.config['instance_id'] = instance['id']
+        self.config['ip_address'] = floating_ip
 
-        return instance['id'], floating_ip
+        return instance['id'], floating_ip['address']
 
     def stop(self):
         logger.info("Stopping VM instance")

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -17,7 +17,6 @@ class IBMVPCInstanceClient:
 
     def __init__(self, ibm_vpc_config):
         logger.debug("Creating IBM VPC client")
-        
         self.name = 'ibm_vpc'
         self.config = ibm_vpc_config
 

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -121,12 +121,18 @@ class IBMVPCInstanceClient:
         return "kpavel-" + namegenerator.gen() + "-" + r_type
 
     def _create_instance(self):
-        security_group_identity_model = {'id': 'r006-2d3cc459-bb8b-4ec6-a5fb-28e60c9f7d7b'}
-        subnet_identity_model = {'id': '0737-bbc80a8f-d46a-4cc6-8a5a-991daa5fc914'}
-        key_identity_model = {'id': "r006-14719c2a-80cf-4043-8018-fa22d4ce1337"}
+        # security_group_identity_model = {'id': 'r006-2d3cc459-bb8b-4ec6-a5fb-28e60c9f7d7b'}
+        security_group_identity_model = {'id': self.config['security_group_id']}
+
+        # subnet_identity_model = {'id': '0737-bbc80a8f-d46a-4cc6-8a5a-991daa5fc914'}
+        subnet_identity_model = {'id': self.config['subnet_id']}
+        
+        # key_identity_model = {'id': "r006-14719c2a-80cf-4043-8018-fa22d4ce1337"}
+        key_identity_model = {'id': self.config['key_id']}
 
         volume_prototype_instance_by_image_context_model = {
-            'capacity': 100, 'iops': 10000, 'name': self._generate_name('volume'), 'profile': {'name': '10iops-tier'}}
+            'capacity': 100, 'iops': 10000, 'name': self._generate_name('volume'), 'profile': {'name': self.config['volume_tier']}}#''10iops-tier'}}
+
         network_interface_prototype_model = {
             'name': 'eth0', 'subnet': subnet_identity_model, 'security_groups': [security_group_identity_model]}
         volume_attachment_prototype_instance_by_image = {
@@ -136,13 +142,12 @@ class IBMVPCInstanceClient:
         }
         instance_prototype_model = {
             'keys': [key_identity_model], 'name': self._generate_name('instance')}
-        instance_prototype_model['profile'] = {'name': "bx2-8x32"}
+        instance_prototype_model['profile'] = {'name': self.config['profile_name']}#"bx2-8x32"}
 
-        instance_prototype_model['resource_group'] = {
-            'id': "8145289ddf7047ea93fd2835de391f43"}
-        instance_prototype_model['vpc'] = {'id': "r006-afdd7b5d-059f-413f-a319-c0a38ef46824"}
-        instance_prototype_model['image'] = {'id': "r006-988caa8b-7786-49c9-aea6-9553af2b1969"}
-        instance_prototype_model['zone'] = {'name': "us-south-3"}
+        instance_prototype_model['resource_group'] = {'id': self.config['resource_group_id']}#"8145289ddf7047ea93fd2835de391f43"}
+        instance_prototype_model['vpc'] = {'id': self.config['vpc_id']}#"r006-afdd7b5d-059f-413f-a319-c0a38ef46824"}
+        instance_prototype_model['image'] = {'id': self.config['image_id']}#"r006-988caa8b-7786-49c9-aea6-9553af2b1969"}
+        instance_prototype_model['zone'] = {'name': self.config['zone_name']}#"us-south-3"}
 
         instance_prototype_model['boot_volume_attachment'] = volume_attachment_prototype_instance_by_image
         instance_prototype_model['primary_network_interface'] = network_interface_prototype_model
@@ -154,8 +159,8 @@ class IBMVPCInstanceClient:
         # allocate new floating ip
         floating_ip_prototype_model = {}
         floating_ip_prototype_model['name'] = self._generate_name('fip')
-        floating_ip_prototype_model['zone'] = {'name': "us-south-3"}
-        floating_ip_prototype_model['resource_group'] = {'id': "8145289ddf7047ea93fd2835de391f43"}
+        floating_ip_prototype_model['zone'] = {'name': self.config['zone_name']}#"us-south-3"}
+        floating_ip_prototype_model['resource_group'] = {'id': self.config['resource_group_id']}#"8145289ddf7047ea93fd2835de391f43"}
 
         response = self.service.create_floating_ip(floating_ip_prototype_model)
         floating_ip = response.result

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -218,7 +218,6 @@ class IBMVPCInstanceClient:
         self.config['ip_address'] = floating_ip
 
         self._wait_instance_running(self.instance_id)
-
         return self.instance_id, floating_ip
 
     def stop(self):

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -183,9 +183,13 @@ class IBMVPCInstanceClient:
 
     def create(self):
         logger.info("Creating VM instance")
+        
         instance = self._create_instance()
         floating_ip = self._create_and_attach_floating_ip(instance)
         logger.debug("VM instance created successfully")
+        self.instance_id = instance['id']
+        self.config['instance_id'] = instance['id']
+
         return instance['id'], floating_ip
 
     def stop(self):

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -221,7 +221,7 @@ class IBMVPCInstanceClient:
         return self.instance_id, floating_ip
 
     def stop(self):
-        if self.config['lowcost']:
+        if self.config['delete_on_dismantle']:
             logger.info("Deleting VM instance")
             self._delete_instance()
             logger.debug("VM instance deleted successfully")

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -5,6 +5,11 @@ import time
 from lithops.constants import COMPUTE_CLI_MSG
 from lithops.util.ibm_token_manager import IBMTokenManager
 
+from ibm_vpc import VpcV1
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_cloud_sdk_core import ApiException
+import namegenerator
+
 logger = logging.getLogger(__name__)
 
 
@@ -12,6 +17,7 @@ class IBMVPCInstanceClient:
 
     def __init__(self, ibm_vpc_config):
         logger.debug("Creating IBM VPC client")
+        
         self.name = 'ibm_vpc'
         self.config = ibm_vpc_config
 
@@ -29,6 +35,10 @@ class IBMVPCInstanceClient:
         self.session = requests.session()
 
         iam_api_key = self.config.get('iam_api_key')
+
+        authenticator = IAMAuthenticator(iam_api_key)
+        self.service = VpcV1('2020-06-02', authenticator=authenticator)
+
         token = self.config.get('token', None)
         token_expiry_time = self.config.get('token_expiry_time', None)
         api_key_type = 'IAM'
@@ -107,10 +117,76 @@ class IBMVPCInstanceClient:
             time.sleep(1)
             self.instance_data = self.get_instance()
 
+    def _generate_name(self, r_type):
+        return "kpavel-" + namegenerator.gen() + "-" + r_type
+
+
+    def _create_instance(self):
+        security_group_identity_model = {'id': 'r006-2d3cc459-bb8b-4ec6-a5fb-28e60c9f7d7b'}
+        subnet_identity_model = {'id': '0737-bbc80a8f-d46a-4cc6-8a5a-991daa5fc914'}
+        key_identity_model = {'id': "r006-14719c2a-80cf-4043-8018-fa22d4ce1337"}
+
+        volume_prototype_instance_by_image_context_model = {
+            'capacity': 100, 'iops': 10000, 'name': self._generate_name('volume'), 'profile': {'name': '10iops-tier'}}
+        network_interface_prototype_model = {
+            'name': 'eth0', 'subnet': subnet_identity_model, 'security_groups': [security_group_identity_model]}
+        volume_attachment_prototype_instance_by_image = {
+            'delete_volume_on_instance_delete': True,
+            'name': self._generate_name('boot'),
+            'volume': volume_prototype_instance_by_image_context_model
+        }
+        instance_prototype_model = {
+            'keys': [key_identity_model], 'name': self._generate_name('instance')}
+        instance_prototype_model['profile'] = {'name': "bx2-8x32"}
+
+        instance_prototype_model['resource_group'] = {
+            'id': "8145289ddf7047ea93fd2835de391f43"}
+        instance_prototype_model['vpc'] = {'id': "r006-afdd7b5d-059f-413f-a319-c0a38ef46824"}
+        instance_prototype_model['image'] = {'id': "r006-988caa8b-7786-49c9-aea6-9553af2b1969"}
+        instance_prototype_model['zone'] = {'name': "us-south-3"}
+
+        instance_prototype_model['boot_volume_attachment'] = volume_attachment_prototype_instance_by_image
+        instance_prototype_model['primary_network_interface'] = network_interface_prototype_model
+
+        response = self.service.create_instance(instance_prototype_model)
+        return response.result
+        
+    def _create_and_attach_floating_ip(self, instance):
+        # allocate new floating ip
+        floating_ip_prototype_model = {}
+        floating_ip_prototype_model['name'] = self._generate_name('fip')
+        floating_ip_prototype_model['zone'] = {'name': "us-south-3"}
+        floating_ip_prototype_model['resource_group'] = {'id': "8145289ddf7047ea93fd2835de391f43"}
+
+        response = self.service.create_floating_ip(floating_ip_prototype_model)
+        floating_ip = response.result
+        
+        # attach floating ip
+        response = self.service.add_instance_network_interface_floating_ip(
+            instance['id'], instance['network_interfaces'][0]['id'], floating_ip['id'])
+
+        return floating_ip
+
+    def _delete_instance(self, instance, floating_ip):
+        # delete vm instance
+        self.service.delete_instance(instance['id'])
+        print("instance {} been deleted".format(instance['name']))
+
+        # delete floating ip
+        self.service.delete_floating_ip(floating_ip['id'])
+        print("floating ip {} been deleted".format(floating_ip['address']))
+
     def start(self):
         logger.info("Starting VM instance")
         self.create_instance_action('start')
         logger.debug("VM instance started successfully")
+
+    def create(self):
+        logger.info("Creating VM instance")
+        instance = self._create_instance()
+        floating_ip = self._create_and_attach_floating_ip(instance)
+        logger.debug("VM instance created successfully")
+        return instance['id'], floating_ip
 
     def stop(self):
         logger.info("Stopping VM instance")

--- a/lithops/standalone/proxy.py
+++ b/lithops/standalone/proxy.py
@@ -114,6 +114,8 @@ def init_keeper():
     with open(config_file, 'r') as cf:
         standalone_config = json.load(cf)
 
+    print('standalone_config', standalone_config)
+
     backend_handler = StandaloneHandler(standalone_config)
     keeper = threading.Thread(target=budget_keeper)
     keeper.daemon = True

--- a/lithops/standalone/proxy.py
+++ b/lithops/standalone/proxy.py
@@ -60,7 +60,7 @@ def budget_keeper():
 
     jobs_running = False
 
-    logger.info("BudgetKeeper started")
+    logger.info("BudgetKeeper started!")
 
     if backend_handler.auto_dismantle:
         logger.info('Auto dismantle activated - Soft timeout: {}s, Hard Timeout: {}s'
@@ -96,7 +96,7 @@ def budget_keeper():
             jobs_running = True
 
         if time_to_dismantle > 0:
-            logger.info("Time to dismantle: {} seconds".format(time_to_dismantle))
+            logger.info("Time to dismantlee: {} seconds".format(time_to_dismantle))
             time.sleep(check_interval)
         else:
             logger.info("Dismantling setup")
@@ -115,6 +115,7 @@ def init_keeper():
         standalone_config = json.load(cf)
 
     print('standalone_config', standalone_config)
+    logger.info('standalone_config {}'.format(standalone_config))
 
     backend_handler = StandaloneHandler(standalone_config)
     keeper = threading.Thread(target=budget_keeper)

--- a/lithops/standalone/proxy.py
+++ b/lithops/standalone/proxy.py
@@ -60,7 +60,7 @@ def budget_keeper():
 
     jobs_running = False
 
-    logger.info("BudgetKeeper started!")
+    logger.info("BudgetKeeper started")
 
     if backend_handler.auto_dismantle:
         logger.info('Auto dismantle activated - Soft timeout: {}s, Hard Timeout: {}s'
@@ -96,7 +96,7 @@ def budget_keeper():
             jobs_running = True
 
         if time_to_dismantle > 0:
-            logger.info("Time to dismantlee: {} seconds".format(time_to_dismantle))
+            logger.info("Time to dismantle: {} seconds".format(time_to_dismantle))
             time.sleep(check_interval)
         else:
             logger.info("Dismantling setup")
@@ -113,9 +113,6 @@ def init_keeper():
     config_file = os.path.join(REMOTE_INSTALL_DIR, 'config')
     with open(config_file, 'r') as cf:
         standalone_config = json.load(cf)
-
-    print('standalone_config', standalone_config)
-    logger.info('standalone_config {}'.format(standalone_config))
 
     backend_handler = StandaloneHandler(standalone_config)
     keeper = threading.Thread(target=budget_keeper)

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -331,7 +331,7 @@ class StandaloneHandler:
         cmd += 'apt-get update >> /tmp/lithops/proxy.log; '
         cmd += 'apt-get install unzip python3-pip -y >> /tmp/lithops/proxy.log; '
         cmd += 'pip3 install flask gevent pika==0.13.1 >> /tmp/lithops/proxy.log; '
-        cmd += 'pip3 install ibm-vpc>=0.3.0 >> /tmp/lithops/proxy.log; '
+        cmd += 'pip3 install "ibm-vpc>=0.3.0" >> /tmp/lithops/proxy.log; '
         cmd += 'unzip -o /tmp/lithops_standalone.zip -d {} > /dev/null 2>&1; '.format(REMOTE_INSTALL_DIR)
         cmd += 'rm /tmp/lithops_standalone.zip; '
         cmd += 'chmod 644 {}; '.format(service_file)

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -283,8 +283,6 @@ class StandaloneHandler:
         instance_id, ip_address = self.backend.create()
         self.ip_address = ip_address
         self.config['instance_id'] = instance_id
-        time.sleep(5)
-        self._wait_backend_ready()
         runtime_meta = self.create_runtime(self.config['runtime'])
         runtime_key = self.get_runtime_key(self.config['runtime'])
         return runtime_key, runtime_meta

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -331,6 +331,7 @@ class StandaloneHandler:
         cmd += 'apt-get update >> /tmp/lithops/proxy.log; '
         cmd += 'apt-get install unzip python3-pip -y >> /tmp/lithops/proxy.log; '
         cmd += 'pip3 install flask gevent pika==0.13.1 >> /tmp/lithops/proxy.log; '
+        cmd += 'pip3 install ibm-vpc>=0.3.0 >> /tmp/lithops/proxy.log; '
         cmd += 'unzip -o /tmp/lithops_standalone.zip -d {} > /dev/null 2>&1; '.format(REMOTE_INSTALL_DIR)
         cmd += 'rm /tmp/lithops_standalone.zip; '
         cmd += 'chmod 644 {}; '.format(service_file)

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -283,6 +283,12 @@ class StandaloneHandler:
         instance_id, ip_address = self.backend.create()
         self.ip_address = ip_address
         self.config['instance_id'] = instance_id
+
+        # Requires further investigation. If not wait after vm create the create_runtime fails
+        # due to interrupted apt update. Another solution could be to specify all preparations in
+        # user_data and wait with runtime_create until user_data finished the setup
+        time.sleep(120)
+
         runtime_meta = self.create_runtime(self.config['runtime'])
         runtime_key = self.get_runtime_key(self.config['runtime'])
         return runtime_key, runtime_meta

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -59,7 +59,7 @@ class StandaloneHandler:
         self.runtime = self.config['runtime']
         self.is_lithops_worker = is_lithops_worker()
 
-        self.start_timeout = self.config.get('start_timeout', 300)
+        self.start_timeout = self.config.get('start_timeout', 600)
 
         self.auto_dismantle = self.config.get('auto_dismantle')
         self.hard_dismantle_timeout = self.config.get('hard_dismantle_timeout')
@@ -273,7 +273,10 @@ class StandaloneHandler:
         """
         Stop VM instance
         """
-        self.backend.stop()
+        if self.config['lowcost']
+            self.backend.delete(self.config['instance_id'])
+        else:
+            self.backend.stop()
 
     def create(self):
         """
@@ -283,6 +286,7 @@ class StandaloneHandler:
         instance_id, ip_address = self.backend.create()
         self.ip_address = ip_address
         self.config['instance_id'] = instance_id
+        time.sleep(60)
         runtime_meta = self.create_runtime(self.config['runtime'])
         runtime_key = self.get_runtime_key(self.config['runtime'])
         return runtime_key, runtime_meta

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -341,4 +341,4 @@ class StandaloneHandler:
         cmd += 'systemctl stop {}; '.format(PROXY_SERVICE_NAME)
         cmd += 'systemctl enable {}; '.format(PROXY_SERVICE_NAME)
         cmd += 'systemctl start {}; '.format(PROXY_SERVICE_NAME)
-        self.ssh_client.run_remote_command(self.ip_address, cmd, background=True)
+        self.ssh_client.run_remote_command(self.ip_address, cmd, timeout=300)

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -278,12 +278,14 @@ class StandaloneHandler:
     def create(self):
         """
         Create VM instance
+        Also installs proxy in the VM to minimize risks of having VM unattended
         """
-        import pdb;pdb.set_trace()
         instance_id, ip_address = self.backend.create()
         self.ip_address = ip_address
         self.config['instance_id'] = instance_id
-        self.init()
+        runtime_meta = self.create_runtime(self.config['runtime'])
+        runtime_key = self.get_runtime_key(self.config['runtime'])
+        return runtime_key, runtime_meta
         
     def init(self):
         """

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -330,8 +330,7 @@ class StandaloneHandler:
         cmd = 'mkdir -p /tmp/lithops; '
         cmd += 'apt-get update >> /tmp/lithops/proxy.log; '
         cmd += 'apt-get install unzip python3-pip -y >> /tmp/lithops/proxy.log; '
-        cmd += 'pip3 install flask gevent pika==0.13.1 >> /tmp/lithops/proxy.log; '
-        cmd += 'pip3 install "ibm-vpc>=0.3.0" >> /tmp/lithops/proxy.log; '
+        cmd += 'pip3 install flask gevent pika==0.13.1 ibm-vpc==0.3.0 namegenerator >> /tmp/lithops/proxy.log; '
         cmd += 'unzip -o /tmp/lithops_standalone.zip -d {} > /dev/null 2>&1; '.format(REMOTE_INSTALL_DIR)
         cmd += 'rm /tmp/lithops_standalone.zip; '
         cmd += 'chmod 644 {}; '.format(service_file)

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -273,10 +273,7 @@ class StandaloneHandler:
         """
         Stop VM instance
         """
-        if self.config['lowcost']
-            self.backend.delete(self.config['instance_id'])
-        else:
-            self.backend.stop()
+        self.backend.stop()
 
     def create(self):
         """

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -283,7 +283,8 @@ class StandaloneHandler:
         instance_id, ip_address = self.backend.create()
         self.ip_address = ip_address
         self.config['instance_id'] = instance_id
-        time.sleep(10)
+        time.sleep(5)
+        self._wait_backend_ready()
         runtime_meta = self.create_runtime(self.config['runtime'])
         runtime_key = self.get_runtime_key(self.config['runtime'])
         return runtime_key, runtime_meta

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -59,7 +59,7 @@ class StandaloneHandler:
         self.runtime = self.config['runtime']
         self.is_lithops_worker = is_lithops_worker()
 
-        self.start_timeout = self.config.get('start_timeout', 600)
+        self.start_timeout = self.config.get('start_timeout', 300)
 
         self.auto_dismantle = self.config.get('auto_dismantle')
         self.hard_dismantle_timeout = self.config.get('hard_dismantle_timeout')

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -275,6 +275,16 @@ class StandaloneHandler:
         """
         self.backend.stop()
 
+    def create(self):
+        """
+        Create VM instance
+        """
+        import pdb;pdb.set_trace()
+        instance_id, ip_address = self.backend.create()
+        self.ip_address = ip_address
+        self.config['instance_id'] = instance_id
+        self.init()
+        
     def init(self):
         """
         Start the VM instance and initialize runtime

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -283,7 +283,7 @@ class StandaloneHandler:
         instance_id, ip_address = self.backend.create()
         self.ip_address = ip_address
         self.config['instance_id'] = instance_id
-        time.sleep(60)
+        time.sleep(10)
         runtime_meta = self.create_runtime(self.config['runtime'])
         runtime_key = self.get_runtime_key(self.config['runtime'])
         return runtime_key, runtime_meta


### PR DESCRIPTION
* New StandaloneExecutor create() API added to provision new temporary VM in IBM VPC
* New delete_on_dismantle boolean flag added under config ibm_vpc section. In case True, the VM instance deleted instead of stopped by default
* Used ibm_vpc python SDK instead. We should consider to change the start/stop to use sdk as well
 
usage example:
```
import lithops

def hello(name):
    print("in hello")
    return 'Hello {}!'.format(name)

if __name__ == '__main__':
  fexec = lithops.StandaloneExecutor(log_level='DEBUG')

  fexec.create()  #provisions vm instance in ibm vpc

  fexec.call_async(hello, 'Worlds')
  print(fexec.get_result())
```

A number of new parameters required under ibm_vpc section in order to provision VMs in IBM VPC:
* security_group_id: <SECURITY_GROUP_ID>
* subnet_id: <SUBNET_ID>
* key_id: <PUBLIC_KEY_ID>
* resource_group_id: <RESOURCE_GROUP_ID>
* vpc_id: <VPC_ID>
* image_id: <IMAGE_ID>
* zone_name: <ZONE_NAME>
* volume_tier_name: <VOLUME_TIER_NAME>  # Optional, 10iops-tier by default
* profile_name: <PROFILE_NAME>  # Optional, bx2-8x32 by default

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

