### PR TITLE
[multiprocessing] Queue and get_context fix

### DIFF
--- a/docs/api_multiprocessing.md
+++ b/docs/api_multiprocessing.md
@@ -252,7 +252,7 @@ When a process first puts an item on the queue a feeder thread is started which 
 |---|---|---|
 | maxsize | Maximum number of elements that can be queued in the queue. | - |
 
-An example is provided [here](../examples/multiprocessing/buffered_queue.py)
+An example is provided [here](../examples/multiprocessing/queue_poll.py)
 
 #### Queue API reference
 

--- a/examples/multiprocessing/buffered_queue.py
+++ b/examples/multiprocessing/buffered_queue.py
@@ -7,7 +7,7 @@ import random
 def work(remote_queue):
     for i in range(5):
         remote_queue.put('Working hard ... {}'.format(i))
-        # time.sleep(random.random())
+        time.sleep(random.random())
 
 
 if __name__ == '__main__':

--- a/examples/multiprocessing/buffered_queue.py
+++ b/examples/multiprocessing/buffered_queue.py
@@ -1,30 +1,30 @@
-from lithops.multiprocessing import Process, Queue, getpid
+import lithops.multiprocessing as mp
+from lithops.multiprocessing import Process, Queue
 import time
+import random
 
 
-def f(q):
-    print("I'm process {}".format(getpid()))
-    q.put([42, None, 'hello'])
-    for i in range(3):
-        q.put('Message no. {} ({})'.format(i, time.time()))
-        time.sleep(1)
-    print('Done')
+def work(remote_queue):
+    for i in range(5):
+        remote_queue.put('Working hard ... {}'.format(i))
+        # time.sleep(random.random())
 
 
 if __name__ == '__main__':
-    q = Queue()
-    p = Process(target=f, args=(q,))
-    p.start()
+    queue = Queue()
+    process = Process(target=work, args=(queue,))
 
-    print(q.get())  # prints "[42, None, 'hello']"
+    # ctx = mp.get_context('spawn')
+    # queue = ctx.Queue()
+    # process = ctx.Process(target=work, args=(queue,))
 
-    consuming = True
-    while consuming:
+    process.start()
+    process.join()
+
+    while True:
         try:
-            res = q.get(block=True, timeout=3)
-            print(res)
-        except q.Empty as e:
+            data = queue.get(timeout=3)
+            print(data)
+        except queue.Empty:
             print('Queue empty!')
-            consuming = False
-
-    p.join()
+            break

--- a/examples/multiprocessing/queue_poll.py
+++ b/examples/multiprocessing/queue_poll.py
@@ -1,0 +1,30 @@
+from lithops.multiprocessing import Process, Queue, getpid
+import time
+
+
+def f(q):
+    print("I'm process {}".format(getpid()))
+    q.put([42, None, 'hello'])
+    for i in range(3):
+        q.put('Message no. {} ({})'.format(i, time.time()))
+        time.sleep(1)
+    print('Done')
+
+
+if __name__ == '__main__':
+    q = Queue()
+    p = Process(target=f, args=(q,))
+    p.start()
+
+    print(q.get())  # prints "[42, None, 'hello']"
+
+    consuming = True
+    while consuming:
+        try:
+            res = q.get(block=True, timeout=3)
+            print(res)
+        except q.Empty as e:
+            print('Queue empty!')
+            consuming = False
+
+    p.join()

--- a/examples/multiprocessing/simple_queue.py
+++ b/examples/multiprocessing/simple_queue.py
@@ -1,4 +1,4 @@
-from lithops.multiprocessing import Process, SimpleQueue
+from lithops.multiprocessing import Process, SimpleQueue, Queue
 
 
 def f(q):
@@ -6,7 +6,8 @@ def f(q):
 
 
 if __name__ == '__main__':
-    q = SimpleQueue()
+    # q = SimpleQueue()
+    q = Queue()
     p = Process(target=f, args=(q,))
     p.start()
     print(q.get())  # prints "[42, None, 'hello']"

--- a/examples/multiprocessing/simple_queue.py
+++ b/examples/multiprocessing/simple_queue.py
@@ -6,8 +6,8 @@ def f(q):
 
 
 if __name__ == '__main__':
-    # q = SimpleQueue()
-    q = Queue()
+    q = SimpleQueue()
+    # q = Queue()
     p = Process(target=f, args=(q,))
     p.start()
     print(q.get())  # prints "[42, None, 'hello']"

--- a/lithops/multiprocessing/__init__.py
+++ b/lithops/multiprocessing/__init__.py
@@ -14,7 +14,7 @@
 # Modifications Copyright (c) 2020 Cloudlab URV
 #
 
-from .context import BaseContext
+from .context import BaseContext, get_context
 from .connection import RedisPipe as Pipe
 from .managers import SyncManager as Manager
 from .pool import Pool

--- a/lithops/multiprocessing/context.py
+++ b/lithops/multiprocessing/context.py
@@ -271,8 +271,8 @@ _concrete_contexts = {
 _default_context = DefaultContext(_concrete_contexts['cloud'])
 
 
-def get_context():
-    return _default_context
+def get_context(method):
+    return _default_context.get_context(method)
 
 
 #

--- a/lithops/multiprocessing/popen_cloud.py
+++ b/lithops/multiprocessing/popen_cloud.py
@@ -63,4 +63,4 @@ class PopenCloud(object):
 
     def _launch(self, process_obj):
         fn_args = [*process_obj._args, *process_obj._kwargs]
-        self.sentinel = self._executor.call_async(process_obj._target, fn_args)
+        self.sentinel = self._executor.call_async(process_obj._target, tuple(fn_args))

--- a/lithops/multiprocessing/queues.py
+++ b/lithops/multiprocessing/queues.py
@@ -63,10 +63,6 @@ class Queue:
 
     def _after_fork(self):
         debug('Queue._after_fork()')
-        self._buffer = collections.deque()
-        self._thread = None
-        self._jointhread = None
-        self._joincancelled = False
         self._closed = False
         self._close = None
         self._send_bytes = self._writer.send_bytes
@@ -78,9 +74,8 @@ class Queue:
             raise ValueError(f"Queue {self!r} is closed")
 
         if self._notfull:
-            if self._thread is None:
-                self._start_thread()
-            self._buffer.append(obj)
+            obj = _ForkingPickler.dumps(obj)
+            self._send_bytes(obj)
 
     def get(self, block=True, timeout=None):
         if block and timeout is None:
@@ -126,81 +121,10 @@ class Queue:
     def join_thread(self):
         debug('Queue.join_thread()')
         assert self._closed
-        if self._jointhread:
-            self._jointhread()
 
     def cancel_join_thread(self):
         debug('Queue.cancel_join_thread()')
-        self._joincancelled = True
-        try:
-            self._jointhread.cancel()
-        except AttributeError:
-            pass
-
-    def _start_thread(self):
-        debug('Queue._start_thread()')
-
-        # Start thread which transfers data from buffer to pipe
-        self._buffer.clear()
-        self._thread = threading.Thread(target=type(self)._feed,
-                                        args=(self._buffer, self._send_bytes, self._writer.close),
-                                        name='QueueFeederThread')
-        self._thread.daemon = True
-
-        debug('doing self._thread.start()')
-        self._thread.start()
-        debug('... done self._thread.start()')
-
-        if not self._joincancelled:
-            self._jointhread = Finalize(self._thread,
-                                        type(self)._finalize_join,
-                                        [weakref.ref(self._thread)],
-                                        exitpriority=-5)
-
-        # Send sentinel to the thread queue object when garbage collected
-        self._close = Finalize(self, type(self)._finalize_close,
-                               [self._buffer], exitpriority=10)
-
-    @staticmethod
-    def _finalize_join(twr):
-        debug('joining queue thread')
-        thread = twr()
-        if thread is not None:
-            thread.join()
-            debug('... queue thread joined')
-        else:
-            debug('... queue thread already dead')
-
-    @staticmethod
-    def _finalize_close(buffer):
-        debug('telling queue thread to quit')
-        buffer.append(Queue._sentinel)
-
-    @staticmethod
-    def _feed(buffer, send_bytes, close):
-        debug('starting thread to feed data to pipe')
-        bpopleft = buffer.popleft
-        sentinel = Queue._sentinel
-
-        while 1:
-            try:
-                obj = bpopleft()
-                if obj is sentinel:
-                    debug('feeder thread got sentinel -- exiting')
-                    close()
-                    return
-
-                obj = _ForkingPickler.dumps(obj)
-                send_bytes(obj)
-            except IndexError:
-                pass
-            except Exception as e:
-                if is_exiting():
-                    info('error in queue thread: %s', e)
-                    return
-                else:
-                    import traceback
-                    traceback.print_exc()
+        pass
 
 
 #


### PR DESCRIPTION
- Fixed `from lithops.multiprocessing import get_context`
- Removed feeder thread for `Queue`: This was a feature inherited from original multiprocessing module using Processes. With Redis and serverless functions it's not necessary and only adds bugs and unexpected behaviors.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

