### PR TITLE
[openwhisk client] support date in json payload

### DIFF
--- a/lithops/libs/openwhisk/client.py
+++ b/lithops/libs/openwhisk/client.py
@@ -210,13 +210,14 @@ class OpenWhiskClient:
                 ctx = ssl._create_unverified_context()
                 conn = http.client.HTTPSConnection(parsed_url.netloc, context=ctx)
                 conn.request("POST", parsed_url.geturl(),
-                             body=json.dumps(payload),
+                             body=json.dumps(payload, default=str),
                              headers=self.headers)
                 resp = conn.getresponse()
                 resp_status = resp.status
                 data = json.loads(resp.read().decode("utf-8"))
                 conn.close()
-        except Exception:
+        except Exception as e:
+            logger.exception('Failed: {}'.format(str(e)))
             if not is_ow_action:
                 conn.close()
             if self_invoked:


### PR DESCRIPTION

 When configuration contains date fields, like `version     : 2020-12-01` the OpenWhisk client will fail to serialize the payload in the invoke method. The exception would be "date time is not serializable json python". To overcome the issue I added "default=str" to the json.dumps . This will enable to use default str for the fields that failed to be serializable
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

