### PR TITLE
Encapsulate map params on multiprocessing api 

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -148,7 +148,7 @@ fexec.map(my_function, kwargs)
 print (fexec.get_result())
 ```
 
-If you want to send a list or a dict as a parameter of the function, you must enclose them with [] as in the next 
+If you want to send a list, a tuple or a dict as a parameter of the function, you must enclose them with () as in the next 
 example.
 
 ```python

--- a/lithops/multiprocessing/pool.py
+++ b/lithops/multiprocessing/pool.py
@@ -257,6 +257,9 @@ class Pool(object):
         Apply `func` to each element in `iterable`, collecting the results
         in a list that is returned.
         """
+        # TODO remove type 'list' whenever using a list in iteradata to enclose multiple args of a function is removed
+        if type(iterable) in (tuple, dict, list):
+            iterable = (iterable, )
         return self._map_async(func, iterable, mapstar, chunksize).get()
 
     def starmap(self, func, iterable, chunksize=None):
@@ -360,6 +363,9 @@ class Pool(object):
         """
         Asynchronous version of `map()` method.
         """
+        # TODO remove type 'list' whenever using a list in iteradata to enclose multiple args of a function is removed
+        if type(iterable) in (tuple, dict, list):
+            iterable = (iterable,)
         return self._map_async(func, iterable, mapstar, chunksize, callback,
                                error_callback)
 


### PR DESCRIPTION
In the multiprocessing api, `map` and `map_async` had the same behaivor as `starmap`. That was because lithops core unpacks params when they come from a tuple, a dict or a list (I believe that list unpacking is deprecated).

This caused the lithops api to behave differently than the native python api. For example, this code:

``` python
def f(x):
    return x[0]

Pool().map(f, [(1,2), (3,4)])
```
In the native multiprocessing returns [1,3], but using lithops it throws a "TypeError: too many positional arguments".

This PR tries to solve that problem with `map` and `map_async` functions, and also fixes a minor error from the docs related to the unpacking. 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

