### PR TITLE
install proxy in create_runtime

### DIFF
--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -266,11 +266,9 @@ class StandaloneHandler:
         """
         if self.provided_backed:
             backend = self.backends[0]
-            if not self._is_proxy_ready(backend):
-                # The VM instance is stopped
-                self._start_backend(backend)
-                self._setup_proxy(backend)
-                self._wait_proxy_ready(backend)
+            self._start_backend(backend)
+            self._setup_proxy(backend)
+            self._wait_proxy_ready(backend)
         else:
             backend = self.create(None, 'proxy', runtime)
 


### PR DESCRIPTION
`standalone.create_runtime()` method must always install the proxy, even if the proxy is already present and running in the VM
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

