### PR TITLE
Force docker localhost executor to use python3

### DIFF
--- a/lithops/localhost/localhost.py
+++ b/lithops/localhost/localhost.py
@@ -144,9 +144,9 @@ class DockerEnv:
     def get_execution_cmd(self, runtime):
         if is_unix_system():
             cmd = ('docker run --user $(id -u):$(id -g) --rm -v {}:/tmp --entrypoint '
-                   '"python" {} /tmp/lithops/runner.py'.format(TEMP, self.runtime))
+                   '"python3" {} /tmp/lithops/runner.py'.format(TEMP, self.runtime))
         else:
-            cmd = ('docker run --rm -v {}:/tmp --entrypoint "python" {} '
+            cmd = ('docker run --rm -v {}:/tmp --entrypoint "python3" {} '
                    '/tmp/lithops/runner.py'.format(TEMP, self.runtime))
         logger.debug(cmd)
         return cmd


### PR DESCRIPTION
Some Docker runtimes I use have both Python2.7 and Python3.
Normally, the entrypoint "python" defaults to Python2.7 for backwards compatibility reasons.
This patch forces localhost docker execution to use "python3" as the container entrypoint.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

