### PR TITLE
[Standalone] Reduce number of ssh connections

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -196,3 +196,4 @@ fexec = lithops.FunctionExecutor(rabbitmq_monitor=True)
 |standalone | auto_dismantle | True |no | If False then the VM is not stopped automatically. Run **exec.dismantle()** explicitly to stop the VM. |
 |standalone | soft_dismantle_timeout | 300 |no| Time in seconds to stop the VM instance after a job **completed** its execution |
 |standalone | hard_dismantle_timeout | 3600 | no | Time in seconds to stop the VM instance after a job **started** its execution |
+|standalone | encryption_key |  | yes | Random key used to encrypt the payload. Use, for example: `openssl rand -base64 32` |

--- a/config/README.md
+++ b/config/README.md
@@ -204,3 +204,4 @@ fexec = lithops.FunctionExecutor(rabbitmq_monitor=True)
 |standalone | exec_mode | consume | no | If set to  **create** standalone backend will automatically create VMs based on the standalone backend|
 |standalone | disable_log_monitoring | False | no | If set to  True pull remote logs will be disabled. This can improve running time|
 |standalone | encryption_key |  | yes | Random key used to encrypt the payload. Use, for example: `openssl rand -base64 32` |
+|standalone | use_http | false | no | `true` or `false`. Whether or not use http connections to communicate with the VM instance. If `falase` (default) it communicates with the VM using ssh connections. If true, it uses the encryption_key to encrypt the payload sent trough http.|

--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -25,6 +25,7 @@ lithops:
     #disable_log_monitoring : False
     #hard_dismantle_timeout: 3600
     #soft_dismantle_timeout: 300
+    #encryption_key: <RANDOM_KEY>
 
 #ibm:
    #iam_api_key: <IAM KEY>

--- a/lithops/standalone/proxy.py
+++ b/lithops/standalone/proxy.py
@@ -145,6 +145,10 @@ def run():
     """
     Run a job
     """
+
+    if flask.request.remote_addr != '127.0.0.1':
+        return error('Wrong request.')
+
     global last_usage_time
     global backend_handler
     global jobs
@@ -260,7 +264,7 @@ def main():
     install_environment()
     init_keeper()
     port = int(os.getenv('PORT', 8080))
-    server = WSGIServer(('127.0.0.1', port), proxy, log=proxy.logger)
+    server = WSGIServer(('0.0.0.0', port), proxy, log=proxy.logger)
     server.serve_forever()
 
 

--- a/lithops/standalone/proxy.py
+++ b/lithops/standalone/proxy.py
@@ -153,13 +153,20 @@ def run():
     global jobs
     global standalone_config
 
-    encrypted_payload = flask.request.data
-    encryption_key = standalone_config['encryption_key']
-    encryption_type = Fernet(encryption_key)
-    try:
-        message = json.loads(encryption_type.decrypt(encrypted_payload))
-    except Exception:
-        return error('The action did not receive a dictionary as an argument.')
+    if 'use_http' in standalone_config and standalone_config['use_http'] is True:
+        logger.info('Running Job. Received invocation through http')
+        encrypted_payload = flask.request.data
+        encryption_key = standalone_config['encryption_key']
+        encryption_type = Fernet(encryption_key)
+        try:
+            message = json.loads(encryption_type.decrypt(encrypted_payload))
+        except Exception:
+            return error('The action did not receive a dictionary as an argument.')
+    else:
+        logger.info('Running Job. Received invocation through ssh')
+        message = flask.request.get_json(force=True, silent=True)
+        if message and not isinstance(message, dict):
+            return error('The action did not receive a dictionary as an argument.')
 
     try:
         runtime = message['job_description']['runtime_name']
@@ -218,54 +225,7 @@ def preinstalls():
     return response
 
 
-def install_environment():
-    """
-    Install docker command and Python deps in case they are not installed.
-    Only for Ubuntu-based OS
-    """
-
-    os_version = sp.check_output('uname -a', shell=True).decode()
-
-    if 'Ubuntu' in os_version:
-        try:
-            sp.check_output('docker ps > /dev/null 2>&1', shell=True)
-            docker_installed = True
-            logger.info("Environment already installed")
-        except Exception:
-            logger.info("Environment not installed")
-            docker_installed = False
-
-        if not docker_installed:
-            # If docker is not installed, nothing is installed, so lets install anything here
-            cmd = 'apt-get remove docker docker-engine docker.io containerd runc -y; '
-            cmd += 'apt-get update '
-            cmd += '&& apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common -y '
-            cmd += '&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - > /dev/null 2>&1 '
-            cmd += '&& add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" '
-            cmd += '&& apt-get update '
-            cmd += '&& apt-get install docker-ce docker-ce-cli containerd.io -y '
-            try:
-                logger.info("Installing Docker...")
-                with open(PX_LOG_FILE, 'a') as lf:
-                    sp.run(cmd, shell=True, stdout=lf, stderr=lf, universal_newlines=True)
-                logger.info("Docker installed successfully")
-            except Exception as e:
-                logger.info("There was an error installing Docker: {}".format(e))
-
-            cmd = 'pip3 install -U lithops'
-            try:
-                logger.info("Installing python packages...")
-                with open(PX_LOG_FILE, 'a') as lf:
-                    sp.run(cmd, shell=True, stdout=lf, stderr=lf, universal_newlines=True)
-                logger.info("Python packages installed successfully")
-            except Exception as e:
-                logger.info("There was an error installing the python packages: {}".format(e))
-    else:
-        logger.info("Linux images different from Ubuntu do not support automatic environment installation")
-
-
 def main():
-    install_environment()
     init_keeper()
     port = int(os.getenv('PORT', 8080))
     server = WSGIServer(('0.0.0.0', port), proxy, log=proxy.logger)

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -228,12 +228,8 @@ class StandaloneHandler:
         logger.debug("_single_invoke - check if proxy ready for  {} ".format(ip_address))
         if not self._is_proxy_ready(backend):
             logger.debug("_single_invoke -  proxy {} stopped".format(ip_address))
-            # The VM instance is stopped
-            init_time = time.time()
             self._start_backend(backend)
             self._wait_proxy_ready(backend)
-            total_start_time = round(time.time()-init_time, 2)
-            logger.info('_single_invoke - VM instance ready in {} seconds'.format(total_start_time))
 
         logger.debug("_single_invoke - before starting log {} ".format(ip_address))
         if self.disable_log_monitoring == 'False':

--- a/lithops/util/ssh_client.py
+++ b/lithops/util/ssh_client.py
@@ -10,6 +10,9 @@ class SSHClient():
         self.ssh_credentials = ssh_credentials
         self.ssh_client = None
 
+    def close(self):
+        self.ssh_client.close()
+
     def create_client(self, ip_address, timeout=None):
         self.ssh_client = paramiko.SSHClient()
         self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -20,7 +23,7 @@ class SSHClient():
 
         return self.ssh_client
 
-    def run_remote_command(self, ip_address, cmd, timeout=None, background=False):
+    def run_remote_command(self, ip_address, cmd, timeout=None, run_async=False):
         if self.ssh_client is None:
             self.ssh_client = self.create_client(ip_address, timeout)
 
@@ -31,7 +34,7 @@ class SSHClient():
             stdin, stdout, stderr = self.ssh_client.exec_command(cmd)
 
         out = None
-        if not background:
+        if not run_async:
             out = stdout.read().decode().strip()
             error = stderr.read().decode().strip()
 

--- a/lithops/util/ssh_client.py
+++ b/lithops/util/ssh_client.py
@@ -26,7 +26,6 @@ class SSHClient():
 
         try:
             stdin, stdout, stderr = self.ssh_client.exec_command(cmd)
-            logger.debug("ssh executed against {} ".format(ip_address))
         except Exception as e:
             self.ssh_client = self.create_client(ip_address, timeout)
             stdin, stdout, stderr = self.ssh_client.exec_command(cmd)
@@ -35,7 +34,6 @@ class SSHClient():
         if not background:
             out = stdout.read().decode().strip()
             error = stderr.read().decode().strip()
-            logger.debug("{}  - {}".format(ip_address, out))
 
         return out
 


### PR DESCRIPTION
Reduce number of ssh connections during installation process
Move `ping` and `get_preinstalls` from ssh to http since they do not contain critical information
Move `run_job` method from ssh to http, using an encription key to encrypt the payload

**ACTIONS REQUIRED:**
**- Open port 8080 in your VPC security group**
**- Add `use_http: true` in the `standalone` section of the config**
**- Add `encription_key: < ENCRYPITON_KEY>` in the `standalone` section of the config**

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

