### PR TITLE
Allow to introduce the runtime at backend level

### DIFF
--- a/config/compute/aliyun_fc.md
+++ b/config/compute/aliyun_fc.md
@@ -25,3 +25,4 @@ $ pip install lithops[aliyun]
    - `public_endpoint`: public endpoint (URL) to the service. OSS and FC endpoints are different.
    - `access_key_id`: Access Key Id.
    - `access_key_secret`: Access Key Secret. 
+   - `runtime`: Runtime name already deployed in the service

--- a/config/compute/aws_lambda.md
+++ b/config/compute/aws_lambda.md
@@ -40,6 +40,7 @@ $ pip install lithops[aws]
  - `access_key_id` and `secret_access_key`: Account access keys to AWS services. To find them, navigate to *My Security Credentials* and click *Create Access Key* if you don't already have one.
  - `region_name`: Region where the S3 bucket is located and where Lambda functions will be invoked (e.g. `us-east-1`).
  - `execution_role`: ARN of the execution role created at step 3. You can find it in the Role page at the *Roles* list in the *IAM* section (e.g. `arn:aws:iam::1234567890:role/lithops-role`).
+ - `runtime`: Runtime name already deployed in the service
  
 #### Additional configuration
 

--- a/config/compute/azure_fa.md
+++ b/config/compute/azure_fa.md
@@ -65,3 +65,4 @@ $ pip install lithops[azure]
 |azure_fa| storage_account | |yes |  The name generated in the step 6 of the installation |
 |azure_fa| storage_account_key |  | yes |  An Account Key, found in *Storage Accounts* > `account_name` > *Settings* > *Access Keys*|
 |azure_fa| location |  |yes | The location of the consumption plan for the runtime. Use `az functionapp list-consumption-locations` to view the available locations.|
+|azure_fa| runtime |  |no | Runtime name already deployed in the service.|

--- a/config/compute/code_engine.md
+++ b/config/compute/code_engine.md
@@ -83,6 +83,7 @@ The only requirement to make it working is to have the KUBECONFIG file properly 
 |knative | max_instances | 250 |no | Maximum number of parallel runtimes |
 |knative | cpu | 1 |no | CPU limit. Default 1vCPU  |
 |knative | concurrency | 1 |no | Number of workers per runtime instance |
+|knative| runtime |  |no | Docker image name.|
 
 
 ### Lithops using Kubernetes Job API of Code Engine
@@ -118,6 +119,7 @@ If you need to create new runtime, please follow [Building and managing Lithops 
 |code_engine | kubectl_config  |  |no | Path to kubecfg file |
 |code_engine | cpu | 1 |no | CPU limit. Default 1vCPU |
 |code_engine | container_registry |  docker.io | no | container registry url|
+|code_engine| runtime |  |no | Docker image name.|
 
 ### Usage Example
 

--- a/config/compute/gcp_functions.md
+++ b/config/compute/gcp_functions.md
@@ -47,3 +47,4 @@ $ pip install lithops[gcp]
  - `service_account`: Service account email of the service account created on step 5 (e.g. `lithops-executor@lithops.iam.gserviceaccount.com`)
  - `credentials_path`: **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`)
  - `region`: Region of the bucket created at step 8. Functions and pub/sub queue will be created in the same region (e.g. `us-east1`)
+ - `runtime`: Runtime name already deployed in the service

--- a/config/compute/ibm_cf.md
+++ b/config/compute/ibm_cf.md
@@ -95,3 +95,4 @@ By default, the IBM Cloud account provides an automatically created CloudFoundry
 |ibm_cf| namespace | |yes | Value of CURRENT NAMESPACE from [here](https://cloud.ibm.com/functions/namespace-settings) |
 |ibm_cf| api_key |  | no | **Mandatory** if using Cloud Foundry-based namespace. Value of 'KEY' from [here](https://cloud.ibm.com/functions/namespace-settings)|
 |ibm_cf| namespace_id |  |no | **Mandatory** if using IAM-based namespace with IAM API Key. Value of 'GUID' from [here](https://cloud.ibm.com/functions/namespace-settings)|
+|ibm_cf| runtime |  |no | Docker image name.|

--- a/config/compute/knative.md
+++ b/config/compute/knative.md
@@ -68,6 +68,7 @@ Note that Lithops automatically builds the default runtime the first time you ru
 |knative | max_instances | 250 |no | Maximum number of parallel runtimes |
 |knative | cpu | 1 |no | CPU limit. Default 1vCPU |
 |knative | concurrency | 1 |no | Number of workers per runtime instance |
+|knative | runtime |  |no | Docker image name.|
 
 
 ### Verify

--- a/config/compute/openwhisk.md
+++ b/config/compute/openwhisk.md
@@ -73,3 +73,4 @@ Lithops with *OpenWhisk* as serverless compute backend. Lithops can also run fun
 |openwhisk | namespace | |yes | Namespace |
 |openwhisk | api_key | |yes | API Auth|
 |openwhisk | insecure | |yes | Insecure access |
+|openwhisk | runtime |  |no | Docker image name.|

--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -38,9 +38,11 @@ lithops:
     #namespace   : <NAMESPACE>
     #api_key     : <API_KEY>
     #namespace_id : <NAMESPACE_ID> # Only for IAM auth
+    #runtime: <RUNTIME_NAME>
 
 #code_engine:
     #kubectl_config: <Location for kubectl yaml file>
+    #runtime: <RUNTIME_NAME>
 
 #ibm_cos:
     region : <REGION>
@@ -82,6 +84,7 @@ lithops:
    #istio_endpoint  : <ISTIO_INGRESS_ENDPOINT>
    #docker_user     : <DOCKER_HUB_USERNAME>
    #docker_token    : <DOCKER_HUB_TOKEN>
+   #runtime: <RUNTIME_NAME>
 
 #docker:
     #host: <HOST_IP>
@@ -93,6 +96,7 @@ lithops:
     #namespace   : <NAMESPACE>
     #api_key     : <AUTH_KEY>
     #insecure    : <True/False>
+    #runtime: <RUNTIME_NAME>
 
 #swift:
     #auth_url   : <SWIFT_AUTH_URL>

--- a/lithops/serverless/backends/aliyun_fc/config.py
+++ b/lithops/serverless/backends/aliyun_fc/config.py
@@ -55,12 +55,23 @@ tblib
 
 def load_config(config_data=None):
 
+    if 'aliyun_fc' not in config_data:
+        raise Exception("aliyun_fc section is mandatory in the configuration")
+
+    required_parameters = ('public_endpoint', 'access_key_id', 'access_key_secret')
+
+    if set(required_parameters) > set(config_data['aliyun_fc']):
+        raise Exception('You must provide {} to access to Aliyun Function Compute '
+                        .format(required_parameters))
+
     this_version_str = version_str(sys.version_info)
     if this_version_str != '3.6':
         raise Exception('The functions backend Aliyun Function Compute currently'
                         ' only supports Python version 3.6.X and the local Python'
                         'version is {}'.format(this_version_str))
 
+    if 'runtime' in config_data['aliyun_fc']:
+        config_data['serverless']['runtime'] = config_data['aliyun_fc']['runtime']
     if 'runtime' not in config_data['serverless']:
         config_data['serverless']['runtime'] = 'default'
 
@@ -81,12 +92,3 @@ def load_config(config_data=None):
             config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
     else:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
-
-    if 'aliyun_fc' not in config_data:
-        raise Exception("aliyun_fc section is mandatory in the configuration")
-
-    required_parameters = ('public_endpoint', 'access_key_id', 'access_key_secret')
-
-    if set(required_parameters) > set(config_data['aliyun_fc']):
-        raise Exception('You must provide {} to access to Aliyun Function Compute '
-                        .format(required_parameters))

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -72,6 +72,10 @@ MAX_CONCURRENT_WORKERS = 1000
 
 
 def load_config(config_data):
+
+    if 'aws' not in config_data and 'aws_lambda' not in config_data:
+        raise Exception("'aws' and 'aws_lambda' sections are mandatory in the configuration")
+
     # Generic serverless config
     if 'runtime_memory' not in config_data['serverless']:
         config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY_DEFAULT
@@ -90,14 +94,13 @@ def load_config(config_data):
                        "maximum amount".format(RUNTIME_TIMEOUT_MAX, config_data['serverless']['runtime_timeout']))
         config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY_MAX
 
+    if 'runtime' in config_data['aws_lambda']:
+        config_data['serverless']['runtime'] = config_data['aws_lambda']['runtime']
     if 'runtime' not in config_data['serverless']:
         config_data['serverless']['runtime'] = 'python{}'.format(version_str(sys.version_info))
 
     if 'workers' not in config_data['lithops']:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
-
-    if 'aws' not in config_data and 'aws_lambda' not in config_data:
-        raise Exception("'aws' and 'aws_lambda' sections are mandatory in the configuration")
 
     # Put credential keys to 'aws_lambda' dict entry
     config_data['aws_lambda'] = {**config_data['aws_lambda'], **config_data['aws']}

--- a/lithops/serverless/backends/azure_fa/config.py
+++ b/lithops/serverless/backends/azure_fa/config.py
@@ -154,6 +154,8 @@ def load_config(config_data=None):
         raise Exception('You must provide {} to access to Azure Function App'
                         .format(required_parameters))
 
+    if 'runtime' in config_data['azure_fa']:
+        config_data['serverless']['runtime'] = config_data['azure_fa']['runtime']
     if 'runtime' not in config_data['serverless']:
         config_data['azure_fa']['functions_version'] = FUNCTIONS_VERSION
         storage_account = config_data['azure_fa']['storage_account']

--- a/lithops/serverless/backends/cloudrun/config.py
+++ b/lithops/serverless/backends/cloudrun/config.py
@@ -41,6 +41,8 @@ def load_config(config_data):
     if 'runtime_timeout' not in config_data['serverless']:
         config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT_DEFAULT
 
+    if 'runtime' in config_data['cloudrun']:
+        config_data['serverless']['runtime'] = config_data['cloudrun']['runtime']
     if 'runtime' not in config_data['serverless']:
         project_id = config_data['cloudrun']['project_id']
         python_version = version_str(sys.version_info).replace('.', '')

--- a/lithops/serverless/backends/code_engine/config.py
+++ b/lithops/serverless/backends/code_engine/config.py
@@ -155,6 +155,8 @@ def load_config(config_data):
     if 'runtime_timeout' not in config_data['serverless']:
         config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT
 
+    if 'runtime' in config_data['code_engine']:
+        config_data['serverless']['runtime'] = config_data['code_engine']['runtime']
     if 'runtime' not in config_data['serverless']:
         if not DOCKER_PATH:
             raise Exception('docker command not found. Install docker or use '

--- a/lithops/serverless/backends/gcp_functions/config.py
+++ b/lithops/serverless/backends/gcp_functions/config.py
@@ -66,13 +66,18 @@ def load_config(config_data=None):
     if config_data is None:
         config_data = {}
 
+    if 'gcp' not in config_data:
+        raise Exception("'gcp' section is mandatory in the configuration")
+
     if 'runtime_memory' not in config_data['serverless']:
         config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY_DEFAULT
     if 'runtime_timeout' not in config_data['serverless']:
         config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT_DEFAULT
+
+    if 'runtime' in config_data['gcp']:
+        config_data['serverless']['runtime'] = config_data['gcp']['runtime']
     if 'runtime' not in config_data['serverless']:
-        config_data['serverless']['runtime'] = 'python' + \
-                                               version_str(sys.version_info)
+        config_data['serverless']['runtime'] = 'python' + version_str(sys.version_info)
 
     if 'workers' not in config_data['lithops']:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
@@ -85,9 +90,6 @@ def load_config(config_data=None):
         config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY_MAX
     if config_data['serverless']['runtime_timeout'] > RUNTIME_TIMEOUT_DEFAULT:
         config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT_DEFAULT
-
-    if 'gcp' not in config_data:
-        raise Exception("'gcp' section is mandatory in the configuration")
 
     config_data['gcp']['retries'] = RETRIES
     config_data['gcp']['retry_sleep'] = RETRY_SLEEP

--- a/lithops/serverless/backends/ibm_cf/config.py
+++ b/lithops/serverless/backends/ibm_cf/config.py
@@ -36,6 +36,10 @@ def load_config(config_data):
         config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY_DEFAULT
     if 'runtime_timeout' not in config_data['serverless']:
         config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT_DEFAULT
+
+    if 'runtime' in config_data['ibm_cf']:
+        config_data['serverless']['runtime'] = config_data['ibm_cf']['runtime']
+
     if 'runtime' not in config_data['serverless']:
         python_version = version_str(sys.version_info)
         try:

--- a/lithops/serverless/backends/knative/config.py
+++ b/lithops/serverless/backends/knative/config.py
@@ -58,6 +58,7 @@ RUN pip install --upgrade setuptools six pip \
         kubernetes \
         numpy \
         cloudpickle \
+        paramiko \
         ps-mem \
         tblib
 
@@ -229,6 +230,9 @@ def load_config(config_data):
         config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY
     if 'runtime_timeout' not in config_data['serverless']:
         config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT
+
+    if 'runtime' in config_data['knative']:
+        config_data['serverless']['runtime'] = config_data['knative']['runtime']
 
     if 'runtime' not in config_data['serverless']:
         if 'docker_user' not in config_data['knative']:

--- a/lithops/serverless/backends/openwhisk/config.py
+++ b/lithops/serverless/backends/openwhisk/config.py
@@ -44,6 +44,9 @@ def load_config(config_data):
     if 'runtime_timeout' not in config_data['serverless']:
         config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT_DEFAULT
 
+    if 'runtime' in config_data['openwhisk']:
+        config_data['serverless']['runtime'] = config_data['openwhisk']['runtime']
+
     if 'runtime' not in config_data['serverless']:
         python_version = version_str(sys.version_info)
         try:

--- a/runtime/code_engine/Dockerfile
+++ b/runtime/code_engine/Dockerfile
@@ -16,15 +16,13 @@ RUN apt-get update \
         libxml2-dev \
         zip \
         unzip \
-        gunicorn \
         make \
     # cleanup package lists, they are not used anymore in this image
     && rm -rf /var/lib/apt/lists/* \
     && apt-cache search linux-headers-generic
 
 COPY requirements.txt requirements.txt
-RUN pip install --upgrade pip setuptools six
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip setuptools six gevent && pip install --no-cache-dir -r requirements.txt
 
 ENV PORT 8080
 ENV CONCURRENCY 4

--- a/runtime/code_engine/requirements.txt
+++ b/runtime/code_engine/requirements.txt
@@ -1,6 +1,7 @@
 # Requirements.txt contains a list of dependencies for the Python Application #
 
 # Setup modules
+gunicorn
 gevent
 flask
 


### PR DESCRIPTION
Currently, the runtime name in serverless mode can only be introduced in the serverless section of the config. With this patch, the runtime name can also be introduced in the backend section
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

