### PR TITLE
Allow invoke_pool_threads to be set in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - [Config] Allow 'log_level' and 'log_format' keys in configuration
 - [Config] Allow 'log_stream' and 'log_filename' keys in configuration
+- [Config] Allow 'runtime' being configured at serverless backend level
+- [Config] Allow 'invoke_pool_threads' being configured at serverless backend level
 
 ### Changed
 - [Core] Renamed utils.setup_logger() method to utils.setup_lithops_logger()

--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -140,14 +140,14 @@ class FunctionExecutor:
 
             if self.config[mode].get('customized_runtime'):
                 self.invoker = CustomizedRuntimeInvoker(self.config,
-                                           self.executor_id,
-                                           self.internal_storage,
-                                           self.compute_handler)
+                                                        self.executor_id,
+                                                        self.internal_storage,
+                                                        self.compute_handler)
             else:
                 self.invoker = ServerlessInvoker(self.config,
-                                             self.executor_id,
-                                             self.internal_storage,
-                                             self.compute_handler)
+                                                 self.executor_id,
+                                                 self.internal_storage,
+                                                 self.compute_handler)
         elif mode == STANDALONE:
             standalone_config = extract_standalone_config(self.config)
             self.compute_handler = StandaloneHandler(standalone_config)
@@ -208,7 +208,7 @@ class FunctionExecutor:
 
     def map(self, map_function, map_iterdata, extra_args=None, extra_env=None,
             runtime_memory=None, chunk_size=None, chunk_n=None, timeout=None,
-            invoke_pool_threads=500, include_modules=[], exclude_modules=[]):
+            invoke_pool_threads=None, include_modules=[], exclude_modules=[]):
         """
         For running multiple function executions asynchronously
 
@@ -260,7 +260,7 @@ class FunctionExecutor:
     def map_reduce(self, map_function, map_iterdata, reduce_function,
                    extra_args=None, extra_env=None, map_runtime_memory=None,
                    reduce_runtime_memory=None, chunk_size=None, chunk_n=None,
-                   timeout=None, invoke_pool_threads=500, reducer_one_per_object=False,
+                   timeout=None, invoke_pool_threads=None, reducer_one_per_object=False,
                    reducer_wait_local=False, include_modules=[], exclude_modules=[]):
         """
         Map the map_function over the data and apply the reduce_function across all futures.
@@ -579,7 +579,7 @@ class FunctionExecutor:
 class LocalhostExecutor(FunctionExecutor):
 
     def __init__(self, config=None, runtime=None, workers=None,
-                 storage=None, rabbitmq_monitor=None, log_level=None):
+                 storage=None, rabbitmq_monitor=None, log_level=False):
         """
         Initialize a LocalhostExecutor class.
 
@@ -602,7 +602,7 @@ class ServerlessExecutor(FunctionExecutor):
 
     def __init__(self, config=None, runtime=None, runtime_memory=None,
                  backend=None, storage=None, workers=None, rabbitmq_monitor=None,
-                 remote_invoker=None, log_level=None):
+                 remote_invoker=None, log_level=False):
         """
         Initialize a ServerlessExecutor class.
 
@@ -627,7 +627,7 @@ class ServerlessExecutor(FunctionExecutor):
 class StandaloneExecutor(FunctionExecutor):
 
     def __init__(self, config=None, backend=None, runtime=None, storage=None,
-                 workers=None, rabbitmq_monitor=None, log_level=None):
+                 workers=None, rabbitmq_monitor=None, log_level=False):
         """
         Initialize a StandaloneExecutor class.
 

--- a/lithops/serverless/backends/aliyun_fc/config.py
+++ b/lithops/serverless/backends/aliyun_fc/config.py
@@ -28,6 +28,7 @@ RUNTIME_TIMEOUT_MAX = 600        # Platform maximum
 RUNTIME_MEMORY_DEFAULT = 256
 RUNTIME_MEMORY_MAX = 3072
 MAX_CONCURRENT_WORKERS = 300
+INVOKE_POOL_THREADS_DEFAULT = 500
 
 CONNECTION_POOL_SIZE = 30
 
@@ -92,3 +93,7 @@ def load_config(config_data=None):
             config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
     else:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
+
+    if 'invoke_pool_threads' not in config_data['aliyun_fc']:
+        config_data['aliyun_fc']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
+    config_data['serverless']['invoke_pool_threads'] = config_data['aliyun_fc']['invoke_pool_threads']

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -69,6 +69,7 @@ RUNTIME_MEMORY_DEFAULT = 256  # Default memory: 256 MB
 RUNTIME_MEMORY_MAX = 10240  # Max. memory: 10240 MB
 
 MAX_CONCURRENT_WORKERS = 1000
+INVOKE_POOL_THREADS_DEFAULT = 500
 
 
 def load_config(config_data):
@@ -140,3 +141,7 @@ def load_config(config_data):
 
     if not all([efs_conf['mount_path'].startswith('/mnt') for efs_conf in config_data['aws_lambda']['efs']]):
         raise Exception("All mount paths must start with '/mnt' on 'aws_lambda/efs/*/mount_path' section")
+
+    if 'invoke_pool_threads' not in config_data['aws_lambda']:
+        config_data['aws_lambda']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
+    config_data['serverless']['invoke_pool_threads'] = config_data['aws_lambda']['invoke_pool_threads']

--- a/lithops/serverless/backends/azure_fa/config.py
+++ b/lithops/serverless/backends/azure_fa/config.py
@@ -34,6 +34,7 @@ RUNTIME_TIMEOUT = 300000    # Default: 300000 ms => 10 minutes
 RUNTIME_TIMEOUT_MAX = 600000        # Platform maximum
 RUNTIME_MEMORY = 1500       # Default memory: 1.5 GB
 MAX_CONCURRENT_WORKERS = 2000
+INVOKE_POOL_THREADS_DEFAULT = 500
 
 IN_QUEUE = "in-trigger"
 OUT_QUEUE = "out-result"
@@ -163,3 +164,7 @@ def load_config(config_data=None):
         revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
         runtime_name = '{}-{}-v{}-{}'.format(storage_account, RUNTIME_NAME, py_version, revision)
         config_data['serverless']['runtime'] = runtime_name
+
+    if 'invoke_pool_threads' not in config_data['azure_fa']:
+        config_data['azure_fa']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
+    config_data['serverless']['invoke_pool_threads'] = config_data['azure_fa']['invoke_pool_threads']

--- a/lithops/serverless/backends/cloudrun/config.py
+++ b/lithops/serverless/backends/cloudrun/config.py
@@ -53,3 +53,7 @@ def load_config(config_data):
     if 'workers' not in config_data['lithops']:
         config_data['cloudrun']['workers'] = CONCURRENT_WORKERS_DEFAULT
         config_data['lithops']['workers'] = CONCURRENT_WORKERS_DEFAULT
+
+    if 'invoke_pool_threads' not in config_data['cloudrun']:
+        config_data['cloudrun']['invoke_pool_threads'] = config_data['lithops']['workers']
+    config_data['serverless']['invoke_pool_threads'] = config_data['cloudrun']['invoke_pool_threads']

--- a/lithops/serverless/backends/code_engine/config.py
+++ b/lithops/serverless/backends/code_engine/config.py
@@ -31,6 +31,7 @@ RUNTIME_TIMEOUT = 600  # Default: 600 seconds => 10 minutes
 RUNTIME_MEMORY = 256  # Default memory: 256 MB
 RUNTIME_CPU = 1  # 1 vCPU
 MAX_CONCURRENT_WORKERS = 1000
+INVOKE_POOL_THREADS_DEFAULT = 4
 
 DEFAULT_GROUP = "codeengine.cloud.ibm.com"
 DEFAULT_VERSION = "v1beta1"
@@ -193,3 +194,7 @@ def load_config(config_data):
     if 'workers' not in config_data['lithops'] or \
        config_data['lithops']['workers'] > MAX_CONCURRENT_WORKERS:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
+
+    if 'invoke_pool_threads' not in config_data['code_engine']:
+        config_data['code_engine']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
+    config_data['serverless']['invoke_pool_threads'] = config_data['code_engine']['invoke_pool_threads']

--- a/lithops/serverless/backends/gcp_functions/config.py
+++ b/lithops/serverless/backends/gcp_functions/config.py
@@ -106,3 +106,7 @@ def load_config(config_data=None):
     config_data['gcp_functions'] = config_data['gcp'].copy()
     if 'region' not in config_data['gcp_functions']:
         config_data['gcp_functions']['region'] = config_data['pywren']['compute_backend_region']
+
+    if 'invoke_pool_threads' not in config_data['gcp']:
+        config_data['gcp']['invoke_pool_threads'] = config_data['lithops']['workers']
+    config_data['serverless']['invoke_pool_threads'] = config_data['gcp']['invoke_pool_threads']

--- a/lithops/serverless/backends/ibm_cf/config.py
+++ b/lithops/serverless/backends/ibm_cf/config.py
@@ -26,6 +26,7 @@ RUNTIME_DEFAULT = {'3.5': 'lithopscloud/ibmcf-python-v35',
 RUNTIME_TIMEOUT_DEFAULT = 600  # Default: 600 seconds => 10 minutes
 RUNTIME_MEMORY_DEFAULT = 256  # Default memory: 256 MB
 MAX_CONCURRENT_WORKERS = 1200
+INVOKE_POOL_THREADS_DEFAULT = 500
 
 
 FH_ZIP_LOCATION = os.path.join(os.getcwd(), 'lithops_ibmcf.zip')
@@ -105,3 +106,7 @@ def load_config(config_data):
 
         if cbr not in config_data['ibm_cf']['regions']:
             raise Exception('Invalid Compute backend region: {}'.format(cbr))
+
+    if 'invoke_pool_threads' not in config_data['ibm_cf']:
+        config_data['ibm_cf']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
+    config_data['serverless']['invoke_pool_threads'] = config_data['ibm_cf']['invoke_pool_threads']

--- a/lithops/serverless/backends/knative/config.py
+++ b/lithops/serverless/backends/knative/config.py
@@ -265,3 +265,7 @@ def load_config(config_data):
         max_instances = config_data['knative']['max_instances']
         concurrency = config_data['knative']['concurrency']
         config_data['lithops']['workers'] = int(max_instances * concurrency)
+
+    if 'invoke_pool_threads' not in config_data['knative']:
+        config_data['knative']['invoke_pool_threads'] = config_data['lithops']['workers']
+    config_data['serverless']['invoke_pool_threads'] = config_data['knative']['invoke_pool_threads']

--- a/lithops/serverless/backends/openwhisk/config.py
+++ b/lithops/serverless/backends/openwhisk/config.py
@@ -26,7 +26,7 @@ RUNTIME_DEFAULT = {'3.5': 'lithopscloud/ibmcf-python-v35',
 RUNTIME_TIMEOUT_DEFAULT = 300  # Default: 300 seconds => 5 minutes
 RUNTIME_MEMORY_DEFAULT = 256  # Default memory: 256 MB
 CONCURRENT_WORKERS_DEFAULT = 100
-
+INVOKE_POOL_THREADS_DEFAULT = 500
 
 FH_ZIP_LOCATION = os.path.join(os.getcwd(), 'lithops_openwhisk.zip')
 
@@ -56,3 +56,7 @@ def load_config(config_data):
 
     if 'workers' not in config_data['lithops']:
         config_data['lithops']['workers'] = CONCURRENT_WORKERS_DEFAULT
+
+    if 'invoke_pool_threads' not in config_data['openwhisk']:
+        config_data['openwhisk']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
+    config_data['serverless']['invoke_pool_threads'] = config_data['openwhisk']['invoke_pool_threads']


### PR DESCRIPTION
Currently, `invoke_pool_threads` can only be configured in runtime. This patch allows to introduce this variable in the config, backend level. #521 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

