### PR TITLE
[IBM CF] Change user_key to API-key pass instead of user

### DIFF
--- a/lithops/serverless/backends/ibm_cf/ibm_cf.py
+++ b/lithops/serverless/backends/ibm_cf/ibm_cf.py
@@ -54,7 +54,7 @@ class IBMCloudFunctionsBackend:
         logger.debug("Set IBM CF Namespace to {}".format(self.namespace))
         logger.debug("Set IBM CF Endpoint to {}".format(self.endpoint))
 
-        self.user_key = self.api_key[:5] if self.api_key else self.iam_api_key[:5]
+        self.user_key = self.api_key.split(':')[1][:4] if self.api_key else self.iam_api_key[:4]
         self.package = 'lithops_v{}_{}'.format(__version__, self.user_key)
 
         if self.api_key:


### PR DESCRIPTION
Now in IBM Cloud Functions backend, each function package contains the first 5 digits of the API key. This patch changes those digits to the first 4 digits of the API key password instead of user (first 4 digits after `:`).

This is useful when more than one user are sharing the same namespace. Now, when one user does `lithops clean`, all functions of all users are deleted. The API key user is shared among all namespace users, but the password isn't. This way, each package is unique identified to the user who created it, and when they execute `lithops clean` only those packages are deleted.




 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

