### PR TITLE
Pass arguments to Pool in joblib backend

### DIFF
--- a/lithops/util/joblib/lithops_backend.py
+++ b/lithops/util/joblib/lithops_backend.py
@@ -64,6 +64,10 @@ class LithopsBackend(ParallelBackendBase, PoolManagerMixin):
     However, does not suffer from the Python Global Interpreter Lock.
     """
 
+    def __init__(self, nesting_level=None, inner_max_num_threads=None, **pool_kwargs):
+        super().__init__(nesting_level, inner_max_num_threads, **{})
+        self.__pool_kwargs = pool_kwargs
+
     # Environment variables to protect against bad situations when nesting
     JOBLIB_SPAWNED_PROCESS = "__JOBLIB_SPAWNED_PARALLEL__"
 
@@ -99,7 +103,7 @@ class LithopsBackend(ParallelBackendBase, PoolManagerMixin):
 
         # Make sure to free as much memory as possible before forking
         gc.collect()
-        self._pool = Pool()
+        self._pool = Pool(**self.__pool_kwargs)
         self.parallel = parallel
 
         return n_jobs


### PR DESCRIPTION
The joblib backend allways creates a Pool in the same way, without passing arguments to the Pool constructor. This PR allows to pass arguments to the Pool constructor in the joblib backend.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

