### PR TITLE
allow different backend in input data

### DIFF
--- a/lithops/config.py
+++ b/lithops/config.py
@@ -16,6 +16,7 @@
 #
 
 import os
+import copy
 import json
 import importlib
 import logging
@@ -37,7 +38,6 @@ CPU_COUNT = mp.cpu_count()
 
 def load_yaml_config(config_filename):
     import yaml
-
     try:
         with open(config_filename, 'r') as config_file:
             data = yaml.safe_load(config_file)
@@ -100,7 +100,7 @@ def load_config(log=True):
 
 def get_log_info(config_data=None):
     """ Return lithops logging information set in configuration """
-    config_data = config_data or load_config(log=False)
+    config_data = copy.deepcopy(config_data) or load_config(log=False)
 
     if 'lithops' not in config_data or not config_data['lithops']:
         config_data['lithops'] = {}
@@ -131,7 +131,7 @@ def get_mode(backend=None, config_data=None):
     elif backend:
         raise Exception("Unknown compute backend: {}".format(backend))
 
-    config_data = config_data or load_config(log=False)
+    config_data = copy.deepcopy(config_data) or load_config(log=False)
 
     if 'lithops' not in config_data or not config_data['lithops']:
         config_data['lithops'] = {}
@@ -150,7 +150,7 @@ def default_config(config_data=None, config_overwrite={}):
     """
     logger.info('Lithops v{}'.format(__version__))
 
-    config_data = config_data or load_config()
+    config_data = copy.deepcopy(config_data) or load_config()
 
     if 'lithops' not in config_data or not config_data['lithops']:
         config_data['lithops'] = {}
@@ -249,7 +249,7 @@ def default_config(config_data=None, config_overwrite={}):
 def default_storage_config(config_data=None, backend=None):
     """ Function to load default storage config """
 
-    config_data = config_data or load_config()
+    config_data = copy.deepcopy(config_data) or load_config()
 
     if 'lithops' not in config_data or not config_data['lithops']:
         config_data['lithops'] = {}

--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -32,9 +32,9 @@ from lithops.invokers import ServerlessInvoker, StandaloneInvoker, CustomizedRun
 from lithops.storage import InternalStorage
 from lithops.wait import wait_storage, wait_rabbitmq, ALL_COMPLETED
 from lithops.job import create_map_job, create_reduce_job
-from lithops.config import get_mode, default_config, extract_storage_config, \
+from lithops.config import get_mode, default_config, \
     extract_localhost_config, extract_standalone_config, \
-    extract_serverless_config, get_log_info
+    extract_serverless_config, get_log_info, extract_storage_config
 from lithops.constants import LOCALHOST, SERVERLESS, STANDALONE, CLEANER_DIR, \
     CLEANER_LOG_FILE
 from lithops.utils import timeout_handler, is_notebook, setup_lithops_logger, \
@@ -405,37 +405,45 @@ class FunctionExecutor:
 
         if is_unix_system() and timeout is not None:
             logger.debug('Setting waiting timeout to {} seconds'.format(timeout))
-            error_msg = 'Timeout of {} seconds exceeded waiting for function activations to finish'.format(timeout)
+            error_msg = ('Timeout of {} seconds exceeded waiting for '
+                         'function activations to finish'.format(timeout))
             signal.signal(signal.SIGALRM, partial(timeout_handler, error_msg))
             signal.alarm(timeout)
 
+        # Setup progress bar
         pbar = None
-        error = False
-
         if not self.is_lithops_worker and self.setup_progressbar:
             from tqdm.auto import tqdm
-
-            if is_notebook():
-                pbar = tqdm(bar_format='{n}/|/ {n_fmt}/{total_fmt}', total=len(fs_not_done))  # ncols=800
-            else:
+            if not is_notebook():
                 print()
-                pbar = tqdm(bar_format='  {l_bar}{bar}| {n_fmt}/{total_fmt}  ', total=len(fs_not_done), disable=None)
+            pbar = tqdm(bar_format='  {l_bar}{bar}| {n_fmt}/{total_fmt}  ',
+                        total=len(fs_not_done), disable=None)
 
+        # Start waiting for results
+        error = False
         try:
             if self.rabbitmq_monitor:
-                wait_rabbitmq(futures, self.internal_storage, rabbit_amqp_url=self.rabbit_amqp_url,
-                              download_results=download_results, throw_except=throw_except,
-                              pbar=pbar, return_when=return_when, THREADPOOL_SIZE=THREADPOOL_SIZE)
+                wait_rabbitmq(futures, self.internal_storage,
+                              rabbit_amqp_url=self.rabbit_amqp_url,
+                              download_results=download_results,
+                              throw_except=throw_except,
+                              pbar=pbar, return_when=return_when,
+                              THREADPOOL_SIZE=THREADPOOL_SIZE)
             else:
-                wait_storage(futures, self.internal_storage, download_results=download_results,
-                             throw_except=throw_except, return_when=return_when, pbar=pbar,
-                             THREADPOOL_SIZE=THREADPOOL_SIZE, WAIT_DUR_SEC=WAIT_DUR_SEC)
+                wait_storage(futures, self.internal_storage,
+                             download_results=download_results,
+                             throw_except=throw_except,
+                             return_when=return_when, pbar=pbar,
+                             THREADPOOL_SIZE=THREADPOOL_SIZE,
+                             WAIT_DUR_SEC=WAIT_DUR_SEC)
 
         except KeyboardInterrupt as e:
             if download_results:
-                not_dones_call_ids = [(f.job_id, f.call_id) for f in futures if not f.done]
+                not_dones_call_ids = [(f.job_id, f.call_id)
+                                      for f in futures if not f.done]
             else:
-                not_dones_call_ids = [(f.job_id, f.call_id) for f in futures if not f.ready and not f.done]
+                not_dones_call_ids = [(f.job_id, f.call_id)
+                                      for f in futures if not f.ready and not f.done]
             msg = ('ExecutorID {} - Cancelled - Total Activations not done: {}'
                    .format(self.executor_id, len(not_dones_call_ids)))
             if pbar:

--- a/lithops/wait/func.py
+++ b/lithops/wait/func.py
@@ -72,16 +72,18 @@ def wait(fs, throw_except=True, return_when=ALL_COMPLETED,
     if not is_lithops_worker() and setup_progressbar:
         from tqdm.auto import tqdm
 
-        if is_notebook():
-            pbar = tqdm(bar_format='{n}/|/ {n_fmt}/{total_fmt}', total=len(fs_not_done))  # ncols=800
-        else:
+        if not is_notebook():
             print()
-            pbar = tqdm(bar_format='  {l_bar}{bar}| {n_fmt}/{total_fmt}  ', total=len(fs_not_done), disable=None)
+        pbar = tqdm(bar_format='  {l_bar}{bar}| {n_fmt}/{total_fmt}  ',
+                    total=len(fs_not_done), disable=None)
 
     try:
-        wait_storage(fs, internal_storage, download_results=download_results,
-                     throw_except=throw_except, return_when=return_when, pbar=pbar,
-                     THREADPOOL_SIZE=THREADPOOL_SIZE, WAIT_DUR_SEC=WAIT_DUR_SEC)
+        wait_storage(fs, internal_storage,
+                     download_results=download_results,
+                     throw_except=throw_except,
+                     return_when=return_when, pbar=pbar,
+                     THREADPOOL_SIZE=THREADPOOL_SIZE,
+                     WAIT_DUR_SEC=WAIT_DUR_SEC)
 
     except KeyboardInterrupt as e:
         if download_results:
@@ -117,7 +119,8 @@ def wait(fs, throw_except=True, return_when=ALL_COMPLETED,
 
 
 def get_result(fs, throw_except=True, timeout=None,
-               THREADPOOL_SIZE=128, WAIT_DUR_SEC=1, internal_storage=None):
+               THREADPOOL_SIZE=128, WAIT_DUR_SEC=1,
+               internal_storage=None):
     """
     For getting the results from all function activations
 
@@ -143,7 +146,8 @@ def get_result(fs, throw_except=True, timeout=None,
     result = []
     fs_done = [f for f in fs_done if not f.futures and f._produce_output]
     for f in fs_done:
-        result.append(f.result(throw_except=throw_except, internal_storage=internal_storage))
+        result.append(f.result(throw_except=throw_except,
+                               internal_storage=internal_storage))
 
     logger.debug("Finished getting results")
 


### PR DESCRIPTION
This patch allows to specify a different backend for the input data to process, for example:

```python
def extract_color(obj):
    print(obj.key)

iterdata = 'cos://josep-datasets'
fexec= lithops.FunctionExecutor(backend="localhost", storage="localhost", log_level='DEBUG')
fexec.map(extract_color, [iterdata], timeout=5)
fexec.get_result()
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

