### PR TITLE
get function and data only once in worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [IBM CF] Change user_key to API-key pass instead of user
 - [Azure] Changed configuration keys
 - [Core] Improved worker when chunksize is set to values > 1
+- [Core] Check lithops version mismatch in host instead of in worker
 
 ### Fixes
 - [Core] Overwrite the runtime set in config with the runtime set in the FunctionExecutor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changed
 - [IBM CF] Change user_key to API-key pass instead of user
 - [Azure] Changed configuration keys
+- [Core] Improved worker when chunksize is set to values > 1
 
 ### Fixes
 - [Core] Overwrite the runtime set in config with the runtime set in the FunctionExecutor

--- a/config/compute/azure_batch.md
+++ b/config/compute/azure_batch.md
@@ -83,7 +83,7 @@ $ python3 -m pip install lithops[azure]
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
-|azure_batch| account_name | |yes | The batch account name |
-|azure_batch| account_key | |yes |  The account key, found in *batch Accounts* > `account_name` > *Settings* > *Keys*|
-|azure_batch| account_url |  |yes | The account, found in *batch Accounts* > `account_name` > *Settings* > *Keys*|
-|azure_batch| runtime |  |no | Runtime name already deployed in the service.|
+|azure_batch| batch_account_name | |yes | The batch account name |
+|azure_batch| batch_account_key | |yes |  The account key, found in *batch Accounts* > `account_name` > *Settings* > *Keys*|
+|azure_batch| batch_account_url |  |yes | The account, found in *batch Accounts* > `account_name` > *Settings* > *Keys*|
+|azure_batch| poolvmsize |  |no | [VM size](https://docs.microsoft.com/es-es/azure/cloud-services/cloud-services-sizes-specs).|

--- a/config/storage/ibm_cos.md
+++ b/config/storage/ibm_cos.md
@@ -26,8 +26,8 @@ The easiest apporach is to let Lithops to choose the right endpoint by itself. T
 Alternative to using region, you can configre public and private endpoints as follows
 
 ```yaml
-	 ibm_cos:
-	     endpoint: https://s3.<region>.cloud-object-storage.appdomain.cloud
+    ibm_cos:
+        endpoint: https://s3.<region>.cloud-object-storage.appdomain.cloud
         private_endpoint: https://s3.private.<region>.cloud-object-storage.appdomain.cloud 
 ```
 

--- a/lithops/constants.py
+++ b/lithops/constants.py
@@ -61,6 +61,7 @@ TEMP = os.path.realpath(tempfile.gettempdir())
 LITHOPS_TEMP_DIR = os.path.join(TEMP, 'lithops')
 JOBS_DIR = os.path.join(LITHOPS_TEMP_DIR, 'jobs')
 LOGS_DIR = os.path.join(LITHOPS_TEMP_DIR, 'logs')
+MODULES_DIR = os.path.join(LITHOPS_TEMP_DIR, 'modules')
 
 RN_LOG_FILE = os.path.join(LITHOPS_TEMP_DIR, 'runner.log')
 FN_LOG_FILE = os.path.join(LITHOPS_TEMP_DIR, 'functions.log')

--- a/lithops/invokers.py
+++ b/lithops/invokers.py
@@ -28,9 +28,9 @@ from threading import Thread
 from types import SimpleNamespace
 from concurrent.futures import ThreadPoolExecutor
 
-from lithops.version import __version__
 from lithops.future import ResponseFuture
 from lithops.config import extract_storage_config
+from lithops.version import __version__ as lithops_version
 from lithops.utils import version_str, is_lithops_worker, is_unix_system, iterchunks
 from lithops.constants import LOGGER_LEVEL, LITHOPS_TEMP_DIR, LOGS_DIR
 from lithops.util.metrics import PrometheusExporter
@@ -85,7 +85,7 @@ class Invoker:
                    'job_key': job.job_key,
                    'call_ids': None,
                    'host_submit_tstamp': time.time(),
-                   'lithops_version': __version__,
+                   'lithops_version': lithops_version,
                    'runtime_name': job.runtime_name,
                    'runtime_memory': job.runtime_memory,
                    'worker_processes': job.worker_processes}
@@ -134,6 +134,10 @@ class StandaloneInvoker(Invoker):
             logger.info('Runtime {} is not yet installed'.format(self.runtime_name))
             runtime_meta = self.compute_handler.create_runtime(self.runtime_name)
             self.internal_storage.put_runtime_meta(runtime_key, runtime_meta)
+
+        if lithops_version != runtime_meta['lithops_version']:
+            raise Exception("Lithops version mismatch. Host version: {} - Runtime version: {}"
+                            .format(lithops_version, runtime_meta['lithops_version']))
 
         py_local_version = version_str(sys.version_info)
         py_remote_version = runtime_meta['python_ver']
@@ -227,7 +231,7 @@ class ServerlessInvoker(Invoker):
         """
         if not runtime_memory:
             runtime_memory = self.config['serverless']['runtime_memory']
-        timeout = self.config['serverless']['runtime_timeout']
+        runtime_timeout = self.config['serverless']['runtime_timeout']
 
         log_msg = ('ExecutorID {} | JobID {} - Selected Runtime: {} - {}MB '
                    .format(self.executor_id, job_id, self.runtime_name, runtime_memory))
@@ -235,14 +239,19 @@ class ServerlessInvoker(Invoker):
 
         runtime_key = self.compute_handler.get_runtime_key(self.runtime_name, runtime_memory)
         runtime_meta = self.internal_storage.get_runtime_meta(runtime_key)
+
         if not runtime_meta:
             logger.info('Runtime {} with {}MB is not yet installed'.format(self.runtime_name, runtime_memory))
-            runtime_meta = self.compute_handler.create_runtime(self.runtime_name, runtime_memory, timeout)
+            runtime_meta = self.compute_handler.create_runtime(self.runtime_name, runtime_memory, runtime_timeout)
+            runtime_meta['runtime_timeout'] = runtime_timeout
             self.internal_storage.put_runtime_meta(runtime_key, runtime_meta)
 
-        py_local_version = version_str(sys.version_info)
-        py_remote_version = runtime_meta['python_ver']
+        if lithops_version != runtime_meta['lithops_version']:
+            raise Exception("Lithops version mismatch. Host version: {} - Runtime version: {}"
+                            .format(lithops_version, runtime_meta['lithops_version']))
 
+        py_local_version = version_str(sys.version_info)
+        py_remote_version = runtime_meta['python_version']
         if py_local_version != py_remote_version:
             raise Exception(("The indicated runtime '{}' is running Python {} and it "
                              "is not compatible with the local Python version {}")

--- a/lithops/serverless/backends/aliyun_fc/entry_point.py
+++ b/lithops/serverless/backends/aliyun_fc/entry_point.py
@@ -21,6 +21,7 @@ from lithops.version import __version__
 from lithops.utils import setup_lithops_logger
 from lithops.worker import function_handler
 from lithops.worker import function_invoker
+from lithops.worker.utils import get_runtime_preinstalls
 
 logger = logging.getLogger('lithops.worker')
 
@@ -28,12 +29,18 @@ logger = logging.getLogger('lithops.worker')
 def main(event, context):
     args = json.loads(event)
     os.environ['__LITHOPS_ACTIVATION_ID'] = context.request_id
+    os.environ['__LITHOPS_BACKEND'] = 'Alibaba Function Compute'
+
     setup_lithops_logger(args['log_level'])
-    if 'remote_invoker' in args:
-        logger.info("Lithops v{} - Starting invoker".format(__version__))
+
+    if 'get_preinstalls' in event:
+        logger.info("Lithops v{} - Generating metadata".format(__version__))
+        return get_runtime_preinstalls()
+    elif 'remote_invoker' in args:
+        logger.info("Lithops v{} - Starting Alibaba Function Compute invoker".format(__version__))
         function_invoker(args)
     else:
-        logger.info("Lithops v{} - Starting execution".format(__version__))
+        logger.info("Lithops v{} - Starting Alibaba Function Compute execution".format(__version__))
         function_handler(args)
 
     return {"Execution": "Finished"}

--- a/lithops/serverless/backends/aws_lambda/entry_point.py
+++ b/lithops/serverless/backends/aws_lambda/entry_point.py
@@ -27,6 +27,7 @@ logger = logging.getLogger('lithops.worker')
 
 def lambda_handler(event, context):
     os.environ['__LITHOPS_ACTIVATION_ID'] = context.aws_request_id
+    os.environ['__LITHOPS_BACKEND'] = 'AWS Lambda'
 
     setup_lithops_logger(event.get('log_level', logging.INFO))
 
@@ -34,10 +35,10 @@ def lambda_handler(event, context):
         logger.info("Lithops v{} - Generating metadata".format(__version__))
         return get_runtime_preinstalls()
     elif 'remote_invoker' in event:
-        logger.info("Lithops v{} - Starting invoker".format(__version__))
+        logger.info("Lithops v{} - Starting AWS Lambda invoker".format(__version__))
         function_invoker(event)
     else:
-        logger.info("Lithops v{} - Starting execution".format(__version__))
+        logger.info("Lithops v{} - Starting AWS Lambda execution".format(__version__))
         function_handler(event)
 
     return {"Execution": "Finished"}

--- a/lithops/serverless/backends/azure_functions/azure_functions.py
+++ b/lithops/serverless/backends/azure_functions/azure_functions.py
@@ -17,7 +17,6 @@
 import os
 import sys
 import ssl
-import uuid
 import json
 import time
 import logging
@@ -169,39 +168,6 @@ class AzureFunctionAppBackend:
             archive.extractall(path=mod_dir)
             os.remove(mod_dir+'/__init__.py')
             os.remove(az_config.FH_ZIP_LOCATION)
-
-    def build_runtime_docker(self, docker_image_name, dockerfile):
-        """
-        Builds a new runtime from a Docker file and pushes it to the Docker hub
-        """
-        logger.debug('Building new docker image from Dockerfile')
-        logger.debug('Docker image name: {}'.format(docker_image_name))
-
-        entry_point = os.path.join(os.path.dirname(__file__), 'entry_point.py')
-        create_handler_zip(az_config.FH_ZIP_LOCATION, entry_point, '__init__.py')
-
-        if dockerfile:
-            cmd = '{} build -t {} -f {} .'.format(az_config.DOCKER_PATH,
-                                                  docker_image_name,
-                                                  dockerfile)
-        else:
-            cmd = '{} build -t {} .'.format(az_config.DOCKER_PATH, docker_image_name)
-
-        if logger.getEffectiveLevel() != logging.DEBUG:
-            cmd = cmd + " >{} 2>&1".format(os.devnull)
-
-        logger.info('Building default runtime')
-        res = os.system(cmd)
-        if res != 0:
-            raise Exception('There was an error building the runtime')
-
-        cmd = '{} push {}'.format(az_config.DOCKER_PATH, docker_image_name)
-        if logger.getEffectiveLevel() != logging.DEBUG:
-            cmd = cmd + " >{} 2>&1".format(os.devnull)
-        res = os.system(cmd)
-        if res != 0:
-            raise Exception('There was an error pushing the runtime to the container registry')
-        logger.debug('Done!')
 
     def _create_function(self, docker_image_name, memory=None,
                          timeout=az_config.RUNTIME_TIMEOUT):

--- a/lithops/serverless/backends/azure_functions/config.py
+++ b/lithops/serverless/backends/azure_functions/config.py
@@ -30,11 +30,17 @@ DOCKER_PATH = shutil.which('docker')
 
 RUNTIME_NAME = 'lithops-runtime'
 FUNCTIONS_VERSION = 3
-RUNTIME_TIMEOUT = 300000    # Default: 300000 ms => 10 minutes
-RUNTIME_TIMEOUT_MAX = 600000        # Platform maximum
+RUNTIME_TIMEOUT = 600    # Default: 600 s => 10 minutes
 RUNTIME_MEMORY = 1536       # Default memory: 1.5 GB
 MAX_CONCURRENT_WORKERS = 200
 INVOKE_POOL_THREADS_DEFAULT = 500
+
+SUPPORTED_PYTHON = ['3.6', '3.7', '3.8', '3.9']
+
+REQUIRED_AZURE_STORAGE_PARAMS = ['storage_account_name', 'storage_account_key']
+REQUIRED_azure_functions_PARAMS = ['resource_group', 'location']
+
+INVOCATION_TYPE_DEFAULT = 'http'
 
 IN_QUEUE = "in-trigger"
 OUT_QUEUE = "out-result"
@@ -157,13 +163,6 @@ RUN mkdir -p /home/site/wwwroo \
     && rm lithops_azure.zip
 """
 
-SUPPORTED_PYTHON = ['3.6', '3.7', '3.8', '3.9']
-
-REQUIRED_AZURE_STORAGE_PARAMS = ['storage_account_name', 'storage_account_key']
-REQUIRED_azure_functions_PARAMS = ['resource_group', 'location']
-
-INVOCATION_TYPE_DEFAULT = 'http'
-
 
 def load_config(config_data=None):
 
@@ -171,17 +170,11 @@ def load_config(config_data=None):
     if python_version not in SUPPORTED_PYTHON:
         raise Exception('Python {} is not supported'.format(python_version))
 
-    if 'runtime_memory' in config_data['serverless']:
-        print("Ignoring user specified '{}'. The current Azure compute backend"
-              " does not support custom runtimes.".format('runtime_memory'))
-        print('Default runtime memory: {}MB'.format(RUNTIME_MEMORY))
-    config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY
+    if 'runtime_memory' not in config_data['serverless']:
+        config_data['serverless']['runtime_memory'] = RUNTIME_MEMORY
 
-    if 'runtime_timeout' in config_data['serverless']:
-        print("Ignoring user specified '{}'. The current Azure compute backend"
-              " does not support custom runtimes.".format('runtime_timeout'))
-        print('Default runtime timeout: {}ms'.format(RUNTIME_TIMEOUT))
-    config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT
+    if 'runtime_timeout' not in config_data['serverless']:
+        config_data['serverless']['runtime_timeout'] = RUNTIME_TIMEOUT
 
     if 'workers' not in config_data['lithops']:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS

--- a/lithops/serverless/backends/azure_functions/entry_point.py
+++ b/lithops/serverless/backends/azure_functions/entry_point.py
@@ -33,36 +33,40 @@ def main_queue(msgIn: func.QueueMessage, msgOut: func.Out[func.QueueMessage]):
     except Exception:
         payload = msgIn.get_json()
 
-    os.environ['__LITHOPS_ACTIVATION_ID'] = str(msgIn.id)
     setup_lithops_logger(payload['log_level'])
+
+    os.environ['__LITHOPS_ACTIVATION_ID'] = str(msgIn.id)
+    os.environ['__LITHOPS_BACKEND'] = 'Azure Functions (event)'
 
     if 'get_preinstalls' in payload:
         logger.info("Lithops v{} - Generating metadata".format(__version__))
         runtime_meta = get_runtime_preinstalls()
         msgOut.set(json.dumps(runtime_meta))
     elif 'remote_invoker' in payload:
-        logger.info("Lithops v{} - Starting invoker".format(__version__))
+        logger.info("Lithops v{} - Starting Azure Functions (event) invoker".format(__version__))
         function_invoker(payload)
     else:
-        logger.info("Lithops v{} - Starting execution".format(__version__))
+        logger.info("Lithops v{} - Starting Azure Functions (event) execution".format(__version__))
         function_handler(payload)
 
 
 def main_http(req: func.HttpRequest, context: func.Context) -> str:
     payload = req.get_json()
 
-    os.environ['__LITHOPS_ACTIVATION_ID'] = context.invocation_id
     setup_lithops_logger(payload['log_level'])
+
+    os.environ['__LITHOPS_ACTIVATION_ID'] = context.invocation_id
+    os.environ['__LITHOPS_BACKEND'] = 'Azure Functions (http)'
 
     if 'get_preinstalls' in payload:
         logger.info("Lithops v{} - Generating metadata".format(__version__))
         runtime_meta = get_runtime_preinstalls()
         return json.dumps(runtime_meta)
     elif 'remote_invoker' in payload:
-        logger.info("Lithops v{} - Starting invoker".format(__version__))
+        logger.info("Lithops v{} - Starting Azure Functions (http) invoker".format(__version__))
         function_invoker(payload)
     else:
-        logger.info("Lithops v{} - Starting execution".format(__version__))
+        logger.info("Lithops v{} - Starting Azure Functions (http) execution".format(__version__))
         function_handler(payload)
 
     return context.invocation_id

--- a/lithops/serverless/backends/code_engine/entry_point.py
+++ b/lithops/serverless/backends/code_engine/entry_point.py
@@ -47,16 +47,17 @@ def run():
     if message and not isinstance(message, dict):
         return error()
 
-    act_id = str(uuid.uuid4()).replace('-', '')[:12]
-    os.environ['__LITHOPS_ACTIVATION_ID'] = act_id
-
     setup_lithops_logger(message['log_level'])
 
+    act_id = str(uuid.uuid4()).replace('-', '')[:12]
+    os.environ['__LITHOPS_ACTIVATION_ID'] = act_id
+    os.environ['__LITHOPS_BACKEND'] = 'Code Engine (Knative)'
+
     if 'remote_invoker' in message:
-        logger.info("Lithops v{} - Starting Knative invoker".format(__version__))
+        logger.info("Lithops v{} - Starting Code Engine (Knative) invoker".format(__version__))
         function_invoker(message)
     else:
-        logger.info("Lithops v{} - Starting Knative execution".format(__version__))
+        logger.info("Lithops v{} - Starting Code Engine (Knative) execution".format(__version__))
         function_handler(message)
 
     response = flask.jsonify({"activationId": act_id})
@@ -102,7 +103,7 @@ def runtime_packages(payload):
 
 
 def main_job(action, encoded_payload):
-    logger.info("Lithops v{} - Starting Code Engine execution".format(__version__))
+    logger.info("Lithops v{} - Starting Code Engine (Job) execution".format(__version__))
 
     payload = b64str_to_dict(encoded_payload)
 
@@ -118,6 +119,7 @@ def main_job(action, encoded_payload):
 
     act_id = str(uuid.uuid4()).replace('-', '')[:12]
     os.environ['__LITHOPS_ACTIVATION_ID'] = act_id
+    os.environ['__LITHOPS_BACKEND'] = 'Code Engine (Job)'
 
     chunksize = payload['chunksize']
     call_ids_ranges = [call_ids_range for call_ids_range in iterchunks(payload['call_ids'], chunksize)]

--- a/lithops/serverless/backends/gcp_cloudrun/entry_point.py
+++ b/lithops/serverless/backends/gcp_cloudrun/entry_point.py
@@ -43,10 +43,11 @@ def run():
     if message and not isinstance(message, dict):
         return error()
 
+    setup_lithops_logger(message['log_level'])
+
     act_id = str(uuid.uuid4()).replace('-', '')[:12]
     os.environ['__LITHOPS_ACTIVATION_ID'] = act_id
-
-    setup_lithops_logger(message['log_level'])
+    os.environ['__LITHOPS_BACKEND'] = 'Google Cloud Run'
 
     if 'remote_invoker' in message:
         logger.info("Lithops v{} - Starting GCP Cloud Run invoker".format(__version__))

--- a/lithops/serverless/backends/gcp_functions/entry_point.py
+++ b/lithops/serverless/backends/gcp_functions/entry_point.py
@@ -27,18 +27,17 @@ from lithops.worker.utils import get_runtime_preinstalls
 from lithops.storage.storage import InternalStorage
 from lithops.constants import JOBS_PREFIX
 
-
-
 logger = logging.getLogger('lithops.worker')
 
 
 def main(event, context):
-    logger.info("Starting GCP Functions function execution")
-
     # pub/sub event data is b64 encoded
     args = json.loads(base64.b64decode(event['data']).decode('utf-8'))
-    os.environ['__LITHOPS_ACTIVATION_ID'] = uuid.uuid4().hex
+
     setup_lithops_logger(args.get('log_level', 'INFO'))
+
+    os.environ['__LITHOPS_ACTIVATION_ID'] = uuid.uuid4().hex
+    os.environ['__LITHOPS_BACKEND'] = 'Google Cloud Functions'
 
     if 'get_preinstalls' in args:
         logger.info("Lithops v{} - Generating metadata".format(__version__))

--- a/lithops/serverless/backends/ibm_cf/entry_point.py
+++ b/lithops/serverless/backends/ibm_cf/entry_point.py
@@ -29,6 +29,7 @@ logger = logging.getLogger('lithops.worker')
 
 def main(args):
     os.environ['__LITHOPS_ACTIVATION_ID'] = os.environ['__OW_ACTIVATION_ID']
+    os.environ['__LITHOPS_BACKEND'] = 'IBM CF'
 
     setup_lithops_logger(args['log_level'], LOGGER_FORMAT_SHORT, sys.stdout)
 

--- a/lithops/serverless/backends/k8s/entry_point.py
+++ b/lithops/serverless/backends/k8s/entry_point.py
@@ -86,6 +86,8 @@ def run_job(encoded_payload):
 
     act_id = str(uuid.uuid4()).replace('-', '')[:12]
     os.environ['__LITHOPS_ACTIVATION_ID'] = act_id
+    os.environ['__LITHOPS_BACKEND'] = 'k8s'
+
     logger.info("Activation ID: {} - Job Index: {}".format(act_id, job_index))
 
     chunksize = payload['chunksize']

--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -187,20 +187,19 @@ class KubernetesBackend:
 
         try:
             jobs = self.batch_api.list_namespaced_job(namespace=self.namespace)
-        except ApiException:
-            pass
-
-        for job in jobs.items:
-            try:
+            for job in jobs.items:
                 if job.metadata.labels['type'] == 'lithops-runtime'\
                    and (job.status.completion_time is not None or force):
                     job_name = job.metadata.name
                     logger.debug('Deleting job {}'.format(job_name))
-                    self.batch_api.delete_namespaced_job(name=job_name,
-                                                         namespace=self.namespace,
-                                                         propagation_policy='Background')
-            except Exception:
-                pass
+                    try:
+                        self.batch_api.delete_namespaced_job(name=job_name,
+                                                             namespace=self.namespace,
+                                                             propagation_policy='Background')
+                    except Exception:
+                        pass
+        except ApiException:
+            pass
 
     def clear(self):
         """

--- a/lithops/serverless/backends/knative/entry_point.py
+++ b/lithops/serverless/backends/knative/entry_point.py
@@ -45,6 +45,7 @@ def run():
 
     act_id = str(uuid.uuid4()).replace('-', '')[:12]
     os.environ['__LITHOPS_ACTIVATION_ID'] = act_id
+    os.environ['__LITHOPS_BACKEND'] = 'Knative'
 
     setup_lithops_logger(message['log_level'])
 

--- a/lithops/serverless/backends/openwhisk/entry_point.py
+++ b/lithops/serverless/backends/openwhisk/entry_point.py
@@ -29,6 +29,7 @@ logger = logging.getLogger('lithops.worker')
 
 def main(args):
     os.environ['__LITHOPS_ACTIVATION_ID'] = os.environ['__OW_ACTIVATION_ID']
+    os.environ['__LITHOPS_BACKEND'] = 'OpenWhisk'
 
     setup_lithops_logger(args['log_level'], LOGGER_FORMAT_SHORT, sys.stdout)
 

--- a/lithops/version.py
+++ b/lithops/version.py
@@ -1,5 +1,5 @@
 
-__version__ = "2.3.1.dev2"
+__version__ = "2.3.1.dev3"
 
 if __name__ == "__main__":
     print(__version__)

--- a/lithops/worker/handler.py
+++ b/lithops/worker/handler.py
@@ -50,8 +50,6 @@ pickling_support.install()
 
 logger = logging.getLogger(__name__)
 
-LITHOPS_LIBS_PATH = '/action/lithops/libs'
-
 
 class ShutdownSentinel():
     """Put an instance of this class on the queue to shut it down"""
@@ -147,7 +145,6 @@ def run_task(task, internal_storage):
     env['LITHOPS_WORKER'] = 'True'
     env['PYTHONUNBUFFERED'] = 'True'
     env['LITHOPS_CONFIG'] = json.dumps(task.config)
-    env['PYTHONPATH'] = "{}:{}".format(os.getcwd(), LITHOPS_LIBS_PATH)
     env['__LITHOPS_SESSION_ID'] = '-'.join([task.job_key, task.id])
     os.environ.update(env)
 
@@ -161,11 +158,6 @@ def run_task(task, internal_storage):
     show_memory_peak = strtobool(os.environ.get('SHOW_MEMORY_PEAK', 'False'))
 
     try:
-        if __version__ != task.lithops_version:
-            msg = ("Lithops version mismatch. Host version: {} - Runtime version: {}"
-                   .format(task.lithops_version, __version__))
-            raise RuntimeError('HANDLER', msg)
-
         # send init status event
         call_status.send('__init__')
 

--- a/lithops/worker/handler.py
+++ b/lithops/worker/handler.py
@@ -37,8 +37,9 @@ from types import SimpleNamespace
 from lithops.version import __version__
 from lithops.config import extract_storage_config
 from lithops.storage import InternalStorage
-from lithops.worker.jobrunner import JobRunner
-from lithops.worker.utils import get_memory_usage, LogStream, custom_redirection
+from lithops.worker.taskrunner import TaskRunner
+from lithops.worker.utils import get_memory_usage, LogStream, custom_redirection,\
+    get_function_and_modules, get_function_data
 from lithops.constants import JOBS_PREFIX, LITHOPS_TEMP_DIR
 from lithops.utils import sizeof_fmt, setup_lithops_logger, is_unix_system
 from lithops.storage.utils import create_status_key, create_job_key,\
@@ -46,7 +47,6 @@ from lithops.storage.utils import create_status_key, create_job_key,\
 
 pickling_support.install()
 
-logging.getLogger('pika').setLevel(logging.CRITICAL)
 logger = logging.getLogger(__name__)
 
 LITHOPS_LIBS_PATH = '/action/lithops/libs'
@@ -61,12 +61,16 @@ def function_handler(payload):
     job = SimpleNamespace(**payload)
     processes = min(job.worker_processes, len(job.call_ids))
 
-    if processes == 1:
-        call_id = job.call_ids.pop(0)
-        data_byte_range = job.data_byte_ranges.pop(0)
-        event = (job, call_id, data_byte_range)
-        event_handler(event)
+    storage_config = extract_storage_config(job.config)
+    internal_storage = InternalStorage(storage_config)
+    job.func = get_function_and_modules(job, internal_storage)
+    job_data = get_function_data(job, internal_storage)
 
+    if processes == 1:
+        task_id = job.call_ids.pop(0)
+        data = job_data.pop(0)
+        event = (job, task_id, data)
+        event_handler(event, internal_storage)
     else:
         manager = SyncManager()
         manager.start()
@@ -76,13 +80,13 @@ def function_handler(payload):
         logger.info("Starting {} processes".format(processes))
 
         for runner_id in range(processes):
-            p = mp.Process(target=process_runner, args=(runner_id, job_queue))
+            p = mp.Process(target=process_runner, args=(runner_id, job_queue, internal_storage))
             job_runners.append(p)
             p.start()
 
-        for call_id in job.call_ids:
-            data_byte_range = job.data_byte_ranges.pop(0)
-            job_queue.put((job, call_id, data_byte_range))
+        for task_id in job.call_ids:
+            data = job_data.pop(0)
+            job_queue.put((job, task_id, data))
 
         for i in range(processes):
             job_queue.put(ShutdownSentinel())
@@ -93,7 +97,7 @@ def function_handler(payload):
         manager.shutdown()
 
 
-def process_runner(runner_id, job_queue):
+def process_runner(runner_id, job_queue, internal_storage):
     """
     Listens the job_queue and executes the jobs
     """
@@ -103,69 +107,67 @@ def process_runner(runner_id, job_queue):
         event = job_queue.get(block=True)
         if isinstance(event, ShutdownSentinel):
             break
-        event_handler(event)
+        event_handler(event, internal_storage)
 
 
-def event_handler(event):
+def event_handler(event, internal_storage):
     """
     Processes a single event
     """
-    job, call_id, data_byte_range = event
+    task, task_id, data = event
+    task.id = task_id
+    task.data = data
 
-    logger.debug('Going to execute job {}-{}'.format(job.job_key, call_id))
+    logger.debug('Going to execute job {}-{}'.format(task.job_key, task_id))
 
-    bucket = job.config['lithops']['storage_bucket']
-    job.job_dir = os.path.join(LITHOPS_TEMP_DIR, bucket, JOBS_PREFIX, job.job_key, call_id)
-    job.log_file = os.path.join(job.job_dir, 'execution.log')
-    os.makedirs(job.job_dir, exist_ok=True)
+    bucket = task.config['lithops']['storage_bucket']
+    task.task_dir = os.path.join(LITHOPS_TEMP_DIR, bucket, JOBS_PREFIX, task.job_key, task_id)
+    task.log_file = os.path.join(task.task_dir, 'execution.log')
+    os.makedirs(task.task_dir, exist_ok=True)
 
-    job.call_id = call_id
-    job.data_byte_range = data_byte_range
-
-    with open(job.log_file, 'a') as log_strem:
-        job.log_stream = LogStream(log_strem)
-        with custom_redirection(job.log_stream):
-            run_job(job)
+    with open(task.log_file, 'a') as log_strem:
+        task.log_stream = LogStream(log_strem)
+        with custom_redirection(task.log_stream):
+            run_task(task, internal_storage)
 
 
-def run_job(job):
+def run_task(task, internal_storage):
     """
     Runs a single job within a separate process
     """
     start_tstamp = time.time()
-    setup_lithops_logger(job.log_level)
+    setup_lithops_logger(task.log_level)
 
     logger.info("Lithops v{} - Starting execution".format(__version__))
-    logger.info("Execution ID: {}/{}".format(job.job_key, job.call_id))
-    logger.debug("Runtime name: {}".format(job.runtime_name))
-    if job.runtime_memory:
-        logger.debug("Runtime memory: {}MB".format(job.runtime_memory))
-    logger.debug("Function timeout: {}s".format(job.execution_timeout))
+    logger.info("Execution ID: {}/{}".format(task.job_key, task.id))
 
-    env = job.extra_env
+    if task.runtime_memory:
+        logger.debug('Runtime: {} - Memory: {} - Timeout: {}'
+                     .format(task.runtime_name, task.runtime_memory, task.execution_timeout))
+    else:
+        logger.debug('Runtime: {} - Timeout: {}'.format(task.runtime_name, task.execution_timeout))
+
+    env = task.extra_env
     env['LITHOPS_WORKER'] = 'True'
     env['PYTHONUNBUFFERED'] = 'True'
-    env['LITHOPS_CONFIG'] = json.dumps(job.config)
+    env['LITHOPS_CONFIG'] = json.dumps(task.config)
     env['PYTHONPATH'] = "{}:{}".format(os.getcwd(), LITHOPS_LIBS_PATH)
-    env['__LITHOPS_SESSION_ID'] = '-'.join([job.job_key, job.call_id])
+    env['__LITHOPS_SESSION_ID'] = '-'.join([task.job_key, task.id])
     os.environ.update(env)
 
-    storage_config = extract_storage_config(job.config)
-    internal_storage = InternalStorage(storage_config)
-
-    call_status = CallStatus(job.config, internal_storage)
+    call_status = CallStatus(task.config, internal_storage)
     call_status.response['worker_start_tstamp'] = start_tstamp
-    call_status.response['host_submit_tstamp'] = job.host_submit_tstamp
-    call_status.response['call_id'] = job.call_id
-    call_status.response['job_id'] = job.job_id
-    call_status.response['executor_id'] = job.executor_id
+    call_status.response['host_submit_tstamp'] = task.host_submit_tstamp
+    call_status.response['call_id'] = task.id
+    call_status.response['job_id'] = task.job_id
+    call_status.response['executor_id'] = task.executor_id
 
     show_memory_peak = strtobool(os.environ.get('SHOW_MEMORY_PEAK', 'False'))
 
     try:
-        if __version__ != job.lithops_version:
+        if __version__ != task.lithops_version:
             msg = ("Lithops version mismatch. Host version: {} - Runtime version: {}"
-                   .format(job.lithops_version, __version__))
+                   .format(task.lithops_version, __version__))
             raise RuntimeError('HANDLER', msg)
 
         # send init status event
@@ -176,15 +178,15 @@ def run_job(job):
             memory_monitor = Thread(target=memory_monitor_worker, args=(mm_conn, ))
             memory_monitor.start()
 
-        job.jr_stats_file = os.path.join(job.job_dir, 'jobrunner.stats.txt')
+        task.stats_file = os.path.join(task.task_dir, 'task_stats.txt')
         handler_conn, jobrunner_conn = Pipe()
-        jobrunner = JobRunner(job, jobrunner_conn, internal_storage)
-        logger.debug('Starting JobRunner process')
-        jrp = Process(target=jobrunner.run) if is_unix_system() else Thread(target=jobrunner.run)
+        taskrunner = TaskRunner(task, jobrunner_conn, internal_storage)
+        logger.debug('Starting TaskRunner process')
+        jrp = Process(target=taskrunner.run) if is_unix_system() else Thread(target=taskrunner.run)
         jrp.start()
 
-        jrp.join(job.execution_timeout)
-        logger.debug('JobRunner process finished')
+        jrp.join(task.execution_timeout)
+        logger.debug('TaskRunner process finished')
 
         if jrp.is_alive():
             # If process is still alive after jr.join(job_max_runtime), kill it
@@ -194,7 +196,7 @@ def run_job(job):
                 # thread does not have terminate method
                 pass
             msg = ('Function exceeded maximum time of {} seconds and was '
-                   'killed'.format(job.execution_timeout))
+                   'killed'.format(task.execution_timeout))
             raise TimeoutError('HANDLER', msg)
 
         if show_memory_peak:
@@ -213,8 +215,8 @@ def run_job(job):
             msg = 'Function exceeded maximum memory and was killed'
             raise MemoryError('HANDLER', msg)
 
-        if os.path.exists(job.jr_stats_file):
-            with open(job.jr_stats_file, 'r') as fid:
+        if os.path.exists(task.stats_file):
+            with open(task.stats_file, 'r') as fid:
                 for l in fid.readlines():
                     key, value = l.strip().split(" ", 1)
                     try:
@@ -239,15 +241,15 @@ def run_job(job):
         call_status.response['worker_end_tstamp'] = time.time()
 
         # Flush log stream and save it to the call status
-        job.log_stream.flush()
-        with open(job.log_file, 'rb') as lf:
+        task.log_stream.flush()
+        with open(task.log_file, 'rb') as lf:
             log_str = base64.b64encode(zlib.compress(lf.read())).decode()
             call_status.response['logs'] = log_str
 
         call_status.send('__end__')
 
         # Unset specific env vars
-        for key in job.extra_env:
+        for key in task.extra_env:
             os.environ.pop(key, None)
         os.environ.pop('__LITHOPS_TOTAL_EXECUTORS', None)
 

--- a/lithops/worker/taskrunner.py
+++ b/lithops/worker/taskrunner.py
@@ -1,6 +1,6 @@
 #
 # (C) Copyright IBM Corp. 2020
-# (C) Copyright Cloudlab URV 2020
+# (C) Copyright Cloudlab URV 2021
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,15 +33,11 @@ from lithops.wait import wait_storage
 from lithops.future import ResponseFuture
 from lithops.utils import sizeof_fmt, is_object_processing_function
 from lithops.utils import WrappedStreamingBodyPartition
-from lithops.constants import TEMP
 from lithops.util.metrics import PrometheusExporter
 from lithops.storage.utils import create_output_key
 from lithops.constants import JOBS_PREFIX
 
 logger = logging.getLogger(__name__)
-
-
-PYTHON_MODULE_PATH = os.path.join(TEMP, "lithops.modules")
 
 
 class stats:
@@ -76,9 +72,6 @@ class TaskRunner:
         prom_enabled = self.lithops_config['lithops'].get('monitoring')
         prom_config = self.lithops_config.get('prometheus', {})
         self.prometheus = PrometheusExporter(prom_enabled, prom_config)
-
-        mode = self.lithops_config['lithops']['mode']
-        self.customized_runtime = self.lithops_config[mode].get('customized_runtime', False)
 
     def _fill_optional_args(self, function, data):
         """

--- a/lithops/worker/taskrunner.py
+++ b/lithops/worker/taskrunner.py
@@ -1,5 +1,4 @@
 #
-# (C) Copyright PyWren Team 2018
 # (C) Copyright IBM Corp. 2020
 # (C) Copyright Cloudlab URV 2020
 #
@@ -32,12 +31,12 @@ from distutils.util import strtobool
 from lithops.storage import Storage
 from lithops.wait import wait_storage
 from lithops.future import ResponseFuture
-from lithops.utils import sizeof_fmt, b64str_to_bytes, is_object_processing_function
+from lithops.utils import sizeof_fmt, is_object_processing_function
 from lithops.utils import WrappedStreamingBodyPartition
 from lithops.constants import TEMP
 from lithops.util.metrics import PrometheusExporter
 from lithops.storage.utils import create_output_key
-from lithops.constants import LITHOPS_TEMP_DIR, JOBS_PREFIX
+from lithops.constants import JOBS_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -59,24 +58,19 @@ class stats:
         self.stats_fid.close()
 
 
-class JobRunner:
+class TaskRunner:
 
-    def __init__(self, job, jobrunner_conn, internal_storage):
+    def __init__(self, task, jobrunner_conn, internal_storage):
+        self.task = task
         self.jobrunner_conn = jobrunner_conn
         self.internal_storage = internal_storage
+        self.lithops_config = task.config
 
-        self.lithops_config = job.config
-        self.executor_id = job.executor_id
-        self.call_id = job.call_id
-        self.job_id = job.job_id
-        self.func_key = job.func_key
-        self.data_key = job.data_key
-        self.data_byte_range = job.data_byte_range
-        self.output_key = create_output_key(JOBS_PREFIX, self.executor_id,
-                                            self.job_id, self.call_id)
+        self.output_key = create_output_key(JOBS_PREFIX, self.task.executor_id,
+                                            self.task.job_id, self.task.id)
 
         # Setup stats class
-        self.stats = stats(job.jr_stats_file)
+        self.stats = stats(self.task.stats_file)
 
         # Setup prometheus for live metrics
         prom_enabled = self.lithops_config['lithops'].get('monitoring')
@@ -85,82 +79,6 @@ class JobRunner:
 
         mode = self.lithops_config['lithops']['mode']
         self.customized_runtime = self.lithops_config[mode].get('customized_runtime', False)
-
-    def _get_function_and_modules(self):
-        """
-        Gets and unpickles function and modules from storage
-        """
-        logger.debug("Getting function and modules")
-        func_download_start_tstamp = time.time()
-        func_obj = None
-        if self.customized_runtime:
-            func_obj = self._get_func()
-        else:
-            func_obj = self.internal_storage.get_func(self.func_key)
-        loaded_func_all = pickle.loads(func_obj)
-        func_download_end_tstamp = time.time()
-        self.stats.write('worker_func_download_time', round(func_download_end_tstamp-func_download_start_tstamp, 8))
-
-        return loaded_func_all
-
-    def _get_func(self):
-        func_path = '/'.join([LITHOPS_TEMP_DIR, self.func_key])
-        with open(func_path, "rb") as f:
-            return f.read()
-
-    def _save_modules(self, module_data):
-        """
-        Save modules, before we unpickle actual function
-        """
-        if module_data:
-            logger.debug("Writing Function dependencies to local disk")
-            module_path = os.path.join(PYTHON_MODULE_PATH, self.executor_id,
-                                       self.job_id, self.call_id)
-            # shutil.rmtree(PYTHON_MODULE_PATH, True)  # delete old modules
-            os.makedirs(module_path, exist_ok=True)
-            sys.path.append(module_path)
-
-            for m_filename, m_data in module_data.items():
-                m_path = os.path.dirname(m_filename)
-
-                if len(m_path) > 0 and m_path[0] == "/":
-                    m_path = m_path[1:]
-                to_make = os.path.join(module_path, m_path)
-                try:
-                    os.makedirs(to_make)
-                except OSError as e:
-                    if e.errno == 17:
-                        pass
-                    else:
-                        raise e
-                full_filename = os.path.join(to_make, os.path.basename(m_filename))
-
-                with open(full_filename, 'wb') as fid:
-                    fid.write(b64str_to_bytes(m_data))
-
-    def _unpickle_function(self, pickled_func):
-        """
-        Unpickle function; it will expect modules to be there
-        """
-        return pickle.loads(pickled_func)
-
-    def _load_data(self):
-        """
-        Loads iteradata
-        """
-        extra_get_args = {}
-        if self.data_byte_range is not None:
-            range_str = 'bytes={}-{}'.format(*self.data_byte_range)
-            extra_get_args['Range'] = range_str
-
-        logger.debug("Getting function data")
-        data_download_start_tstamp = time.time()
-        data_obj = self.internal_storage.get_data(self.data_key, extra_get_args=extra_get_args)
-        loaded_data = pickle.loads(data_obj)
-        data_download_end_tstamp = time.time()
-        self.stats.write('worker_data_download_time', round(data_download_end_tstamp-data_download_start_tstamp, 8))
-
-        return loaded_data
 
     def _fill_optional_args(self, function, data):
         """
@@ -191,7 +109,7 @@ class JobRunner:
                 raise Exception('Cannot create the rabbitmq client: missing configuration')
 
         if 'id' in func_sig.parameters:
-            data['id'] = int(self.call_id)
+            data['id'] = int(self.task.id)
 
     def _wait_futures(self, data):
         logger.info('Reduce function: waiting for map results')
@@ -262,15 +180,8 @@ class JobRunner:
         result = None
         exception = False
         try:
-            function = None
-
-            if self.customized_runtime:
-                function = self._get_function_and_modules()
-            else:
-                loaded_func_all = self._get_function_and_modules()
-                self._save_modules(loaded_func_all['module_data'])
-                function = self._unpickle_function(loaded_func_all['func'])
-            data = self._load_data()
+            function = pickle.loads(self.task.func)
+            data = pickle.loads(self.task.data)
 
             if strtobool(os.environ.get('__LITHOPS_REDUCE_JOB', 'False')):
                 self._wait_futures(data)
@@ -282,8 +193,8 @@ class JobRunner:
             self.prometheus.send_metric(name='function_start',
                                         value=time.time(),
                                         labels=(
-                                            ('job_id', self.job_id),
-                                            ('call_id', self.call_id),
+                                            ('job_id', self.task.job_id),
+                                            ('call_id', self.task.id),
                                             ('function_name', function.__name__)
                                         ))
 
@@ -298,8 +209,8 @@ class JobRunner:
             self.prometheus.send_metric(name='function_end',
                                         value=time.time(),
                                         labels=(
-                                            ('job_id', self.job_id),
-                                            ('call_id', self.call_id),
+                                            ('job_id', self.task.job_id),
+                                            ('call_id', self.task.id),
                                             ('function_name', function.__name__)
                                         ))
 
@@ -351,6 +262,7 @@ class JobRunner:
                                             'pickle_exception': pickle_exception})
                 pickle.loads(pickled_exc)  # this is just to make sure it can be unpickled
                 self.stats.write("exc_info", str(pickled_exc))
+
         finally:
             store_result = strtobool(os.environ.get('STORE_RESULT', 'True'))
             if result is not None and store_result and not exception:

--- a/lithops/worker/utils.py
+++ b/lithops/worker/utils.py
@@ -1,13 +1,112 @@
+#
+# (C) Copyright Cloudlab URV 2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import sys
 import pkgutil
+import logging
+import pickle
 import subprocess
 from contextlib import contextmanager
-from lithops.utils import sizeof_fmt, is_unix_system
+
+from lithops.utils import sizeof_fmt, is_unix_system, b64str_to_bytes
+from lithops.constants import TEMP, LITHOPS_TEMP_DIR
+
+PYTHON_MODULE_PATH = os.path.join(TEMP, "lithops.modules")
+
+logger = logging.getLogger(__name__)
+
 
 if is_unix_system():
     # Windows hosts can't use ps_mem module
     import ps_mem
+
+
+def get_function_and_modules(job, internal_storage):
+    """
+    Gets the function and the modules from storage
+    """
+    logger.debug("Getting function and modules")
+
+    mode = job.config['lithops']['mode']
+    customized_runtime = job.config[mode].get('customized_runtime', False)
+
+    func_obj = None
+    if customized_runtime:
+        func_path = '/'.join([LITHOPS_TEMP_DIR, job.func_key])
+        with open(func_path, "rb") as f:
+            func_obj = f.read()
+    else:
+        func_obj = internal_storage.get_func(job.func_key)
+    loaded_func_all = pickle.loads(func_obj)
+
+    if loaded_func_all['module_data']:
+        logger.debug("Writing Function dependencies to local disk")
+        module_path = os.path.join(PYTHON_MODULE_PATH, job.job_key)
+        # shutil.rmtree(PYTHON_MODULE_PATH, True)  # delete old modules
+        os.makedirs(module_path, exist_ok=True)
+        sys.path.append(module_path)
+
+        for m_filename, m_data in loaded_func_all['module_data'].items():
+            m_path = os.path.dirname(m_filename)
+
+            if len(m_path) > 0 and m_path[0] == "/":
+                m_path = m_path[1:]
+            to_make = os.path.join(module_path, m_path)
+            try:
+                os.makedirs(to_make)
+            except OSError as e:
+                if e.errno == 17:
+                    pass
+                else:
+                    raise e
+            full_filename = os.path.join(to_make, os.path.basename(m_filename))
+
+            with open(full_filename, 'wb') as fid:
+                fid.write(b64str_to_bytes(m_data))
+
+    return loaded_func_all['func']
+
+
+def get_function_data(job, internal_storage):
+    """
+    Get function data (iteradata) from storage
+    """
+    logger.debug("Getting function data")
+
+    extra_get_args = {}
+    if job.data_byte_ranges is not None:
+        init_byte = job.data_byte_ranges[0][0]
+        last_byte = job.data_byte_ranges[-1][1]
+        range_str = 'bytes={}-{}'.format(init_byte, last_byte)
+        extra_get_args['Range'] = range_str
+
+    data_obj = internal_storage.get_data(job.data_key, extra_get_args=extra_get_args)
+
+    loaded_data = []
+    offset = 0
+    if job.data_byte_ranges is not None:
+        for dbr in job.data_byte_ranges:
+            length = dbr[1] - dbr[0] + 1
+            loaded_data.append(data_obj[offset:offset+length])
+            offset += length
+    else:
+        loaded_data.append(data_obj)
+
+    return loaded_data
 
 
 def get_memory_usage(formatted=True):


### PR DESCRIPTION
Currently, when using the `chunksize` parameter, each task in the worker creates 1 storage client and makes 2 calls to the storage backend to get the function and the data. These number of requests increase linearly based on `chunksize`, so if for example `chunksize=100`, each worker will create 100 storage clients and make a total of 200 requests to the storage backend.

With this patch, the storage client is created _per worker_ and not _per task_, so with this if `chunksize=100` (or any other value), the worker will always create only 1 client, and make 2 requests to the object storage to get the function and the data.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

