### PR TITLE
Fix CLI issue

### DIFF
--- a/lithops/scripts/cli.py
+++ b/lithops/scripts/cli.py
@@ -78,7 +78,7 @@ def clean(config, mode, backend, storage, debug):
         compute_handler = LocalhostHandler(compute_config)
     elif mode == SERVERLESS:
         compute_config = extract_serverless_config(config)
-        compute_handler = ServerlessHandler(compute_config, storage_config)
+        compute_handler = ServerlessHandler(compute_config, internal_storage)
     elif mode == STANDALONE:
         compute_config = extract_standalone_config(config)
         compute_handler = StandaloneHandler(compute_config)
@@ -347,7 +347,7 @@ def create(name, storage, backend, memory, timeout, config):
     internal_storage = InternalStorage(storage_config)
 
     compute_config = extract_serverless_config(config)
-    compute_handler = ServerlessHandler(compute_config, storage_config)
+    compute_handler = ServerlessHandler(compute_config, internal_storage)
     mem = memory if memory else compute_config['runtime_memory']
     to = timeout if timeout else compute_config['runtime_timeout']
     runtime_key = compute_handler.get_runtime_key(name, mem)
@@ -383,8 +383,10 @@ def build(name, file, config, backend):
         name = config[mode]['runtime']
 
     storage_config = extract_storage_config(config)
+    internal_storage = InternalStorage(storage_config)
+
     compute_config = extract_serverless_config(config)
-    compute_handler = ServerlessHandler(compute_config, storage_config)
+    compute_handler = ServerlessHandler(compute_config, internal_storage)
     compute_handler.build_runtime(name, file)
 
 
@@ -416,7 +418,7 @@ def update(name, config, backend, storage):
     storage_config = extract_storage_config(config)
     internal_storage = InternalStorage(storage_config)
     compute_config = extract_serverless_config(config)
-    compute_handler = ServerlessHandler(compute_config, storage_config)
+    compute_handler = ServerlessHandler(compute_config, internal_storage)
 
     timeout = compute_config['runtime_memory']
     logger.info('Updating runtime: {}'.format(name))
@@ -461,7 +463,7 @@ def delete(name, config, backend, storage):
     storage_config = extract_storage_config(config)
     internal_storage = InternalStorage(storage_config)
     compute_config = extract_serverless_config(config)
-    compute_handler = ServerlessHandler(compute_config, storage_config)
+    compute_handler = ServerlessHandler(compute_config, internal_storage)
 
     runtimes = compute_handler.list_runtimes(name)
     for runtime in runtimes:


### PR DESCRIPTION
`ServerlessHandler` constructor args changed in #613 (storage_config was replaced by an instance of InternalStorage directly). The CLI script, where instances of `ServerlessHandler` are created, wasn't updated. This patch fixes this issue.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

