### PR TITLE
Delete pika=0.13.1 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## [v2.3.1.dev2]
+## [v2.3.2.dev0]
+
+### Added
+- 
+
+### Changed
+- [Core] Deleted strong dependency to pika==0.13.1
+
+### Fixes
+- [Cli] Fixed serverless runtime lifecycle methods
+
+
+## [v2.3.1]
 
 ### Added
 - [Core] Allow Support for Python 3.9

--- a/lithops/serverless/backends/aliyun_fc/config.py
+++ b/lithops/serverless/backends/aliyun_fc/config.py
@@ -39,7 +39,7 @@ FH_ZIP_LOCATION = os.path.join(os.getcwd(), 'lithops_aliyunfc.zip')
 REQUIREMENTS_FILE = """
 aliyun-fc2
 oss2
-pika==0.13.1
+pika
 flask
 gevent
 glob2

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -43,7 +43,7 @@ DEFAULT_REQUIREMENTS = [
     'Pillow',
     'pandas',
     'redis',
-    'pika==0.13.1',
+    'pika',
     'cloudpickle',
     'ps-mem',
     'tblib'

--- a/lithops/serverless/backends/azure_functions/config.py
+++ b/lithops/serverless/backends/azure_functions/config.py
@@ -120,7 +120,7 @@ REQUIREMENTS_FILE = """
 azure-functions
 azure-storage-blob
 azure-storage-queue
-pika==0.13.1
+pika
 flask
 gevent
 glob2
@@ -147,7 +147,7 @@ RUN pip install --upgrade setuptools six pip \
         azure-functions \
         azure-storage-blob \
         azure-storage-queue \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \

--- a/lithops/serverless/backends/code_engine/config.py
+++ b/lithops/serverless/backends/code_engine/config.py
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         gunicorn \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \

--- a/lithops/serverless/backends/gcp_cloudrun/config.py
+++ b/lithops/serverless/backends/gcp_cloudrun/config.py
@@ -48,7 +48,7 @@ RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         wheel \
         gunicorn \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \

--- a/lithops/serverless/backends/gcp_functions/config.py
+++ b/lithops/serverless/backends/gcp_functions/config.py
@@ -48,7 +48,7 @@ DEFAULT_REQUIREMENTS = [
     'jmespath',
     'kafka-python',
     'lxml',
-    'pika==0.13.0',
+    'pika',
     'redis',
     'requests',
     'six',

--- a/lithops/serverless/backends/k8s/config.py
+++ b/lithops/serverless/backends/k8s/config.py
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         flask \
-        pika==0.13.1 \
+        pika \
         glob2 \
         ibm-cos-sdk \
         redis \

--- a/lithops/serverless/backends/knative/config.py
+++ b/lithops/serverless/backends/knative/config.py
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         gunicorn \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \

--- a/runtime/aliyun_fc/requirements.txt
+++ b/runtime/aliyun_fc/requirements.txt
@@ -1,6 +1,6 @@
 aliyun-fc2
 oss2
-pika==0.13.1
+pika
 flask
 gevent
 glob2

--- a/runtime/aws_lambda/Dockerfile.python38
+++ b/runtime/aws_lambda/Dockerfile.python38
@@ -29,7 +29,7 @@ RUN pip install \
         numpy \
         scipy \
         pandas \
-        pika==0.13.1 \
+        pika \
         kafka-python \
         cloudpickle \
         ps-mem \

--- a/runtime/aws_lambda/requirements.txt
+++ b/runtime/aws_lambda/requirements.txt
@@ -3,7 +3,7 @@ kafka-python
 requests
 Pillow
 redis
-pika==0.13.1
+pika
 cloudpickle
 ps-mem
 tblib

--- a/runtime/code_engine/requirements.txt
+++ b/runtime/code_engine/requirements.txt
@@ -43,6 +43,6 @@ ibm-cos-sdk
 psycopg2-binary
 #pymongo
 redis
-pika == 0.13.1
+pika
 #elasticsearch
 etcd3

--- a/runtime/gcp_cloudrun/Dockerfile
+++ b/runtime/gcp_cloudrun/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         wheel \
         gunicorn \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \

--- a/runtime/gcp_cloudrun/Dockerfile.conda
+++ b/runtime/gcp_cloudrun/Dockerfile.conda
@@ -22,7 +22,7 @@ RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         wheel \
         gunicorn \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \

--- a/runtime/gcp_functions/requirements.txt
+++ b/runtime/gcp_functions/requirements.txt
@@ -13,7 +13,7 @@ idna
 jmespath
 kafka-python
 lxml
-pika==0.13.0
+pika
 python-dateutil
 redis
 requests

--- a/runtime/ibm_cf/Dockerfile.slim
+++ b/runtime/ibm_cf/Dockerfile.slim
@@ -11,7 +11,7 @@ RUN pip install --upgrade pip setuptools six \
         kafka_python \
         lxml \
         python-dateutil \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         ibm-cos-sdk \

--- a/runtime/ibm_cf/requirements.txt
+++ b/runtime/ibm_cf/requirements.txt
@@ -43,6 +43,6 @@ ibm-vpc
 psycopg2-binary
 #pymongo
 redis
-pika == 0.13.1
+pika
 #elasticsearch
 etcd3

--- a/runtime/knative/Dockerfile
+++ b/runtime/knative/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         gunicorn \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \

--- a/runtime/knative/Dockerfile.conda
+++ b/runtime/knative/Dockerfile.conda
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --upgrade setuptools six pip \
     && pip install --no-cache-dir \
         gunicorn \
-        pika==0.13.1 \
+        pika \
         flask \
         gevent \
         glob2 \


### PR DESCRIPTION
After some tests I could verify that `pika==0.13.1` is no longer necessary and users can use any newer version
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

