### PR TITLE
Allow private container registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - [Core] Allow to execute a Class as lithops function
 - [CE] Allow to to run code engine without kubecfg file
+- [CE] Allow private container registries
+- [k8s] Allow private container registries
+- [knative] Allow private container registries
 
 ### Changed
 - [CE] CPU and memory values must match predefined flavors

--- a/config/compute/code_engine.md
+++ b/config/compute/code_engine.md
@@ -131,7 +131,8 @@ If you need to create custom runtime, please follow [Building and managing Litho
 |code_engine | namespace |  |no | Namespace name|
 |code_engine | region |  | no | Cluster region. One of *us-south*, *jp-tok*, *eu-de*, *eu-gb* |
 |code_engine | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
-|code_engine | container_registry |  docker.io | no | container registry url|
+|code_engine | container_registry |  docker.io | no | container registry name|
+|code_engine | docker_server | https://index.docker.io/v1/ |no | Docker server URL |
 |code_engine | docker_user | |no | Docker hub username |
 |code_engine | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |code_engine | runtime |  |no | Docker image name.|
@@ -157,7 +158,8 @@ The only requirement to make it working is to have the KUBECONFIG file properly 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
 |knative | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
-|knative | container_registry |  docker.io | no | container registry url|
+|knative | container_registry |  docker.io | no | container registry name|
+|knative | docker_server | https://index.docker.io/v1/ |no | Docker server URL |
 |knative | docker_user | |no | Docker hub username |
 |knative | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |knative | git_url | |no | Git repository to build the image |

--- a/config/compute/code_engine.md
+++ b/config/compute/code_engine.md
@@ -132,6 +132,8 @@ If you need to create custom runtime, please follow [Building and managing Litho
 |code_engine | region |  | no | Cluster region. One of *us-south*, *jp-tok*, *eu-de*, *eu-gb* |
 |code_engine | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
 |code_engine | container_registry |  docker.io | no | container registry url|
+|code_engine | docker_user | |no | Docker hub username |
+|code_engine | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |code_engine | runtime |  |no | Docker image name.|
 |code_engine | runtime_cpu | 0.125 |no | CPU limit. Default 0.125vCPU. See [valid combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
 |code_engine | runtime_memory | 256 |no | Memory limit in MB. Default 256Mi. See [valid combinations](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
@@ -157,7 +159,7 @@ The only requirement to make it working is to have the KUBECONFIG file properly 
 |knative | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
 |knative | container_registry |  docker.io | no | container registry url|
 |knative | docker_user | |no | Docker hub username |
-|knative | docker_token | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
+|knative | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |knative | git_url | |no | Git repository to build the image |
 |knative | git_rev | |no | Git revision to build the image |
 |knative | min_instances | 0 |no | Minimum number of parallel runtimes |

--- a/config/compute/k8s_job.md
+++ b/config/compute/k8s_job.md
@@ -32,6 +32,7 @@ Lithops with kubernetes as serverless compute backend.
 |---|---|---|---|---|
 |k8s | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
 |k8s | container_registry |  docker.io | no | container registry url|
+|k8s | docker_server | https://index.docker.io/v1/ |no | Docker server URL |
 |k8s | docker_user | |no | Docker hub username |
 |k8s | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |k8s | runtime |  |no | Docker image name.|

--- a/config/compute/k8s_job.md
+++ b/config/compute/k8s_job.md
@@ -33,7 +33,7 @@ Lithops with kubernetes as serverless compute backend.
 |k8s | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
 |k8s | container_registry |  docker.io | no | container registry url|
 |k8s | docker_user | |no | Docker hub username |
-|k8s | docker_token | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
+|k8s | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |k8s | runtime |  |no | Docker image name.|
 |k8s | runtime_cpu | 0.125 |no | CPU limit. Default 0.125vCPU |
 |k8s | runtime_memory | 256 |no | Memory limit in MB. Default 256Mi |

--- a/config/compute/knative.md
+++ b/config/compute/knative.md
@@ -59,7 +59,8 @@ Note that Lithops automatically builds the default runtime the first time you ru
 |---|---|---|---|---|
 |knative | istio_endpoint | |no | Istio IngressGateway Endpoint. Make sure to use http:// prefix |
 |knative | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
-|knative | container_registry |  docker.io | no | container registry url|
+|knative | container_registry |  docker.io | no | container registry name|
+|knative | docker_server | https://index.docker.io/v1/ |no | Docker server URL |
 |knative | docker_user | |no | Docker hub username |
 |knative | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |knative | git_url | |no | Git repository to build the image |

--- a/config/compute/knative.md
+++ b/config/compute/knative.md
@@ -61,7 +61,7 @@ Note that Lithops automatically builds the default runtime the first time you ru
 |knative | kubecfg_path | |no | Path to kubecfg file. Mandatory if config file not in `~/.kube/config` or KUBECONFIG env var not present|
 |knative | container_registry |  docker.io | no | container registry url|
 |knative | docker_user | |no | Docker hub username |
-|knative | docker_token | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
+|knative | docker_password | |no | Login to your docker hub account and generate a new access token [here](https://hub.docker.com/settings/security)|
 |knative | git_url | |no | Git repository to build the image |
 |knative | git_rev | |no | Git revision to build the image |
 |knative | min_instances | 0 |no | Minimum number of parallel runtimes |

--- a/lithops/serverless/backends/code_engine/config.py
+++ b/lithops/serverless/backends/code_engine/config.py
@@ -112,6 +112,8 @@ spec:
         requests:
           cpu: '1'
           memory: 128Mi
+    imagePullSecrets:
+      - name: lithops-regcred
 """
 
 

--- a/lithops/serverless/backends/k8s/config.py
+++ b/lithops/serverless/backends/k8s/config.py
@@ -84,31 +84,33 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: "lithops"
-        image: "<INPUT>"
-        command: ["python3"]
-        args:
-        - "/lithops/lithopsentry.py"
-        - "$(ACTION)"
-        - "$(PAYLOAD)"
-        env:
-        - name: ACTION
-          value: ''
-        - name: PAYLOAD
-          value: ''
-        - name: IDGIVER_POD_IP
-          value: ''
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        resources:
-          requests:
-            cpu: '0.2'
-            memory: 128Mi
-          limits:
-            cpu: '0.2'
-            memory: 128Mi
+        - name: "lithops"
+          image: "<INPUT>"
+          command: ["python3"]
+          args:
+            - "/lithops/lithopsentry.py"
+            - "$(ACTION)"
+            - "$(PAYLOAD)"
+          env:
+            - name: ACTION
+              value: ''
+            - name: PAYLOAD
+              value: ''
+            - name: IDGIVER_POD_IP
+              value: ''
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: '0.2'
+              memory: 128Mi
+            limits:
+              cpu: '0.2'
+              memory: 128Mi
+      imagePullSecrets:
+        - name: lithops-regcred
 """
 
 

--- a/lithops/serverless/backends/knative/config.py
+++ b/lithops/serverless/backends/knative/config.py
@@ -192,19 +192,21 @@ spec:
       containerConcurrency: 1
       timeoutSeconds: 600
       containers:
-      - image: IMAGE
-        env:
-          - name: CONCURRENCY
-            value: "1"
-          - name: TIMEOUT
-            value: "600"
-        resources:
-          limits:
-            memory: "256Mi"
-            cpu: "1"
-          requests:
-            memory: "256Mi"
-            cpu: "1"
+        - image: IMAGE
+          env:
+            - name: CONCURRENCY
+              value: "1"
+            - name: TIMEOUT
+              value: "600"
+          resources:
+            limits:
+              memory: "256Mi"
+              cpu: "1"
+            requests:
+              memory: "256Mi"
+              cpu: "1"
+      imagePullSecrets:
+        - name: lithops-regcred
 """
 
 

--- a/lithops/serverless/backends/knative/knative.py
+++ b/lithops/serverless/backends/knative/knative.py
@@ -163,7 +163,7 @@ class KnativeServingBackend:
         """
         logger.debug("Creating Tekton account resources: Secret and ServiceAccount")
         string_data = {'username': self.knative_config['docker_user'],
-                       'password': self.knative_config['docker_token']}
+                       'password': self.knative_config['docker_password']}
         secret_res = yaml.safe_load(kconfig.secret_res)
         secret_res['stringData'] = string_data
 
@@ -258,8 +258,8 @@ class KnativeServingBackend:
 
         logger.debug("Building default Lithops runtime from git with Tekton")
 
-        if not {"docker_user", "docker_token"} <= set(self.knative_config):
-            raise Exception("You must provide 'docker_user' and 'docker_token'"
+        if not all(key in ["docker_user", "docker_password"] for key in self.knative_config):
+            raise Exception("You must provide 'docker_user' and 'docker_password'"
                             " to build the default runtime")
 
         task_run = yaml.safe_load(kconfig.task_run)


### PR DESCRIPTION
Allow private container registries in K8s, Code Engine and knative backends #505 

_Note: Currently only docker hub is tested_
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

