### PR TITLE
[AWS Lambda] Pinned awslambdaric on Dockerfile

### DIFF
--- a/runtime/aws_lambda/Dockerfile.python38
+++ b/runtime/aws_lambda/Dockerfile.python38
@@ -21,7 +21,7 @@ RUN mkdir -p ${FUNCTION_DIR}
 # Install the function's dependencies
 RUN pip install \
     --target ${FUNCTION_DIR} \
-        awslambdaric \
+        awslambdaric==1.0.0 \
         boto3 \
         redis \
         httplib2 \


### PR DESCRIPTION
The module `awslambdaric`, which is required for the Lambda container runtimes, has been updated recently and the last version is not compatible with the current AWS Lambda backend implementation. As a temporary fix, I've pinned the package to the version that doesn't break our Lambda backend until I investigate further and find a proper solution for this issue.



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

