### PR TITLE
Fix wrapper streaming body

### DIFF
--- a/lithops/utils.py
+++ b/lithops/utils.py
@@ -480,51 +480,51 @@ class WrappedStreamingBodyPartition(WrappedStreamingBody):
         # Range of the chunk
         self.range = byterange
         # The first chunk does not contain plusbyte
-        self.plusbytes = 0 if not self.range or self.range[0] == 0 else 1
+        self._plusbytes = 0 if not self.range or self.range[0] == 0 else 1
         # To store the first byte of this chunk, which actually is the last byte of previous chunk
-        self.first_byte = None
+        self._first_byte = None
         # Flag that indicates the end of the file
-        self.eof = False
+        self._eof = False
+        # special logic the first time the stream is read
+        self._first_read = True
 
     def read(self, n=None):
-        if self.eof:
-            raise EOFError()
+        if self._eof:
+            return b''
         # Data always contain one byte from the previous chunk,
         # so l'ets check if it is a \n or not
-        if self.plusbytes != 0:
-            self.first_byte = self.sb.read(self.plusbytes)
+        if not self._first_byte and self._plusbytes == 1:
+            self._first_byte = self.sb.read(self._plusbytes)
 
         retval = self.sb.read(n)
-
-        if retval == "":
-            raise EOFError()
 
         self.pos += len(retval)
         first_row_start_pos = 0
 
-        if self.first_byte != b'\n' and self.plusbytes == 1:
+        if self._first_read and self._first_byte != b'\n' and self._plusbytes == 1:
             logger.debug('Discarding first partial row')
             # Previous byte is not \n
             # This means that we have to discard first row because it is cut
             first_row_start_pos = retval.find(b'\n')+1
+            self._first_read = False
 
         last_row_end_pos = self.pos
         # Find end of the line in threshold
         if self.pos > self.chunk_size:
-            buf = io.BytesIO(retval[self.chunk_size-self.plusbytes:])
+            buf = io.BytesIO(retval[self.chunk_size-self._plusbytes:])
             buf.readline()
-            last_row_end_pos = self.chunk_size-self.plusbytes+buf.tell()
-            self.eof = True
+            last_row_end_pos = self.chunk_size-self._plusbytes+buf.tell()
+            self._eof = True
 
         return retval[first_row_start_pos:last_row_end_pos]
 
     def readline(self):
-        if self.eof:
-            raise EOFError()
+        if self._eof:
+            return b''
 
-        if not self.first_byte and self.plusbytes != 0:
-            self.first_byte = self.sb.read(self.plusbytes)
-            if self.first_byte != b'\n':
+        if not self._first_byte and self._plusbytes == 1:
+            self._first_byte = self.sb.read(self._plusbytes)
+            if self._first_byte != b'\n':
                 logger.debug('Discarding first partial row')
                 self.sb._raw_stream.readline()
         try:
@@ -534,6 +534,6 @@ class WrappedStreamingBodyPartition(WrappedStreamingBody):
         self.pos += len(retval)
 
         if self.pos >= self.chunk_size:
-            self.eof = True
+            self._eof = True
 
         return retval


### PR DESCRIPTION
- Return an empty byte string when EOF instead of raising an exception
- Avoid multiple "discarding first partial row" logic when the read() method is called multiple times
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

