### PR TITLE
[AWS Lambda] Update Dockerfile & config parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [v2.3.5.dev0]
 
 ### Added
-- 
+- [AWS Lambda] Add 'account_id' parameter in config (used if present instead of querying STS).
 
 ### Changed
-- Add 'key' and 'bucket' attrs in localhost partitioner for compatibility with OS
+- [Core] Add 'key' and 'bucket' attrs in localhost partitioner for compatibility with OS
 
 ### Fixes
 - 

--- a/config/compute/aws_lambda.md
+++ b/config/compute/aws_lambda.md
@@ -12,13 +12,34 @@ $ python3 -m pip install lithops[aws]
 
 2. [Login](https://console.aws.amazon.com/?nc2=h_m_mc) to Amazon Web Services Console (or signup if you don't have an account)
  
-3. Navigate to *IAM > Roles*. Click on *Create Role*.
- 
-4. Select *Lambda* and then click *Next: Permissions*.
- 
-5. Type `s3` at the search bar and select *AmazonS3FullAccess*. Type `lambda` at the search bar and select *AWSLambdaFullAccess*. Click on *Next: Tags* and then *Next: Review*.
- 
-6. Type a role name, for example `lithops-execution-role`. Click on *Create Role*.
+3. Navigate to **IAM > Policies**. Click on **Create policy**.
+
+4. Select **JSON** tab and paste the following JSON policy:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:*",
+                "lambda:*",
+                "ec2:*",
+                "ecr:*",
+                "sts:GetCallerIdentity"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+5. Click **Next: Tags** and **Next: Review**. Fill the policy name field (you can name it `lithops-policy` or simmilar) and create the policy.
+
+6. Go back to **IAM** and navigate to **Roles** tab. Click **Create role**.
+
+7. Choose **Lambda** on the use case list and click **Next: Permissions**. Select the policy created before (`lithops-policy`). Click **Next: Tags** and **Next: Review**. Type a role name, for example `lithops-execution-role`. Click on *Create Role*.
 
 ### Configuration
 
@@ -31,6 +52,7 @@ $ python3 -m pip install lithops[aws]
     aws:
         access_key_id: <ACCESS_KEY_ID>
         secret_access_key: <SECRET_ACCESS_KEY>
+        #account_id: <ACCOUNT_ID>  # Optional
 
     aws_lambda:
         execution_role: <EXECUTION_ROLE_ARN>
@@ -40,7 +62,7 @@ $ python3 -m pip install lithops[aws]
  - `access_key_id` and `secret_access_key`: Account access keys to AWS services. To find them, navigate to *My Security Credentials* and click *Create Access Key* if you don't already have one.
  - `region_name`: Region where the S3 bucket is located and where Lambda functions will be invoked (e.g. `us-east-1`).
  - `execution_role`: ARN of the execution role created at step 3. You can find it in the Role page at the *Roles* list in the *IAM* section (e.g. `arn:aws:iam::1234567890:role/lithops-role`).
- - `runtime`: Runtime name already deployed in the service
+ - `account_id`: *Optional*. This field will be used if present to retrieve the account ID instead of using AWS STS. The account ID is used to format full image names for container runtimes.
  
 #### Additional configuration
 

--- a/lithops/serverless/backends/aws_lambda/aws_lambda.py
+++ b/lithops/serverless/backends/aws_lambda/aws_lambda.py
@@ -76,8 +76,11 @@ class AWSLambdaBackend:
 
         self.internal_storage = internal_storage
 
-        sts_client = self.aws_session.client('sts', region_name=self.region_name)
-        self.account_id = sts_client.get_caller_identity()["Account"]
+        if self.aws_lambda_config['account_id']:
+            self.account_id = self.aws_lambda_config['account_id']
+        else:
+            sts_client = self.aws_session.client('sts', region_name=self.region_name)
+            self.account_id = sts_client.get_caller_identity()["Account"]
 
         self.ecr_client = self.aws_session.client('ecr', region_name=self.region_name)
 

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -88,12 +88,12 @@ def load_config(config_data):
     if 'workers' not in config_data['lithops']:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
 
-    # Put credential keys to 'aws_lambda' dict entry
-    config_data['aws_lambda'] = {**config_data['aws_lambda'], **config_data['aws']}
-
     # Auth, role and region config
     if not {'access_key_id', 'secret_access_key'}.issubset(set(config_data['aws'])):
         raise Exception("'access_key_id' and 'secret_access_key' are mandatory under 'aws' section")
+
+    if 'account_id' not in config_data['aws']:
+        config_data['aws']['account_id'] = None
 
     if not {'execution_role', 'region_name'}.issubset(set(config_data['aws_lambda'])):
         raise Exception("'execution_role' and 'region_name' are mandatory under 'aws_lambda' section")
@@ -130,3 +130,6 @@ def load_config(config_data):
     if 'invoke_pool_threads' not in config_data['aws_lambda']:
         config_data['aws_lambda']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
     config_data['serverless']['invoke_pool_threads'] = config_data['aws_lambda']['invoke_pool_threads']
+
+    # Put credential keys to 'aws_lambda' dict entry
+    config_data['aws_lambda'] = {**config_data['aws_lambda'], **config_data['aws']}

--- a/runtime/aws_lambda/Dockerfile.python38
+++ b/runtime/aws_lambda/Dockerfile.python38
@@ -18,10 +18,13 @@ RUN apt-get update && \
 # Copy function code
 RUN mkdir -p ${FUNCTION_DIR}
 
+# Update pip
+RUN pip install -U pip wheel six setuptools
+
 # Install the function's dependencies
 RUN pip install \
     --target ${FUNCTION_DIR} \
-        awslambdaric==1.0.0 \
+        awslambdaric \
         boto3 \
         redis \
         httplib2 \
@@ -47,11 +50,14 @@ WORKDIR ${FUNCTION_DIR}
 COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 
 # Add Lithops
-RUN mkdir lithops
 COPY lithops_lambda.zip ${FUNCTION_DIR}
-RUN unzip lithops_lambda.zip && rm lithops_lambda.zip
+RUN unzip lithops_lambda.zip \
+    && rm lithops_lambda.zip \
+    && mkdir handler \
+    && touch handler/__init__.py \
+    && mv __main__.py handler/
 
 # Put your dependencies here, using RUN pip install... or RUN apt install...
 
 ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
-CMD [ "__main__.lambda_handler" ]
+CMD [ "handler.__main__.lambda_handler" ]


### PR DESCRIPTION
- Dockerfile for container runtimes updated. `awslambdaric` is no longer pinned (https://github.com/lithops-cloud/lithops/pull/665).
- Added `account_id` in config parameters. It will be used if present instead of querying STS (https://github.com/lithops-cloud/lithops/issues/661).
- Updated AWS Lambda configuration docs. Added a JSON ready to use policy for copy-paste instead of manual selection of policies.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

