### PR TITLE
Add function chaining pattern in the Futures API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## [v2.3.5.dev0]
 
 ### Added
-- [Core] make ob.data_stream an iterator when using the partitioner
+- [Core] Add function chaining patter in the Futures API
+- [Core] ob.data_stream is now also an iterator when using the partitioner
 - [AWS Lambda] Add 'account_id' parameter in config (used if present instead of querying STS).
 
 ### Changed
 - [Core] Add 'key' and 'bucket' attrs in localhost partitioner for compatibility with OS
+- [Serverless] runtime, runtime_memory and runtime_timeout can only be set at backend level
 
 ### Fixes
 - [Standalone] Fix execution

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ from lithops import Storage
 
 if __name__ == "__main__":
     storage = Storage()
-    storage.put_object(bucket='my-bucket',
+    storage.put_object(bucket='mybucket',
                        key='test.txt',
                        body='Hello World')
-    ...
-    print(storage.get_object(bucket='my-bucket',
+
+    print(storage.get_object(bucket='mybucket',
                              key='test.txt'))
 ```
 </td>

--- a/config/README.md
+++ b/config/README.md
@@ -167,10 +167,10 @@ fexec = lithops.FunctionExecutor(monitoring='rabbitmq')
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
-|lithops|storage_bucket | |yes | Any bucket that exists in your COS account. This will be used by Lithops for intermediate data |
-|lithops | storage | ibm_cos | no | Storage backend implementation. IBM Cloud Object Storage is the default |
-|lithops| data_cleaner | True | no |If set to True, then the cleaner will automatically delete all the temporary data that was written into `storage_bucket/lithops.jobs`|
 |lithops | mode | serverless | no | Execution mode. One of: **localhost**, **serverless** or **standalone** |
+|lithops | storage | ibm_cos | no | Storage backend implementation. IBM Cloud Object Storage is the default |
+|lithops|storage_bucket | |yes | Any bucket that exists in your COS account. This will be used by Lithops for intermediate data |
+|lithops| data_cleaner | True | no |If set to True, then the cleaner will automatically delete all the temporary data that was written into `storage_bucket/lithops.jobs`|
 |lithops | monitoring | storage | no | Monitoring system implementation. One of: **storage** or **rabbitmq** |
 |lithops | workers | Depends on the compute backend | no | Max number of concurrent workers |
 |lithops| data_limit | 4 | no | Max (iter)data size (in MB). Set to False for unlimited size |
@@ -183,19 +183,16 @@ fexec = lithops.FunctionExecutor(monitoring='rabbitmq')
 |lithops|log_filename |  |no | Path to a file. log_filename has preference over log_stream. |
 
 
-## Summary of configuration keys for Serverless
+
+### Summary of configuration keys for Servverless
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
 |serverless | backend | ibm_cf |no | Serverless compute backend implementation. IBM Cloud Functions is the default |
-|serverless | runtime | Depends on the backend | no | Runtime name to run the functions. |
-|serverless | runtime_memory | 256 | no | Default runtime memory (in MB) |
-|serverless | runtime_timeout | 600 | no |  Default serveless backend runtime timeout (in seconds) |
 |serverless | remote_invoker | False | no |  Activate the remote invoker feature that uses one cloud function to spawn all the actual `map()` activations |
 |serverless | customized_runtime | False | no | Enables early preparation of Lithops workers with the map function and custom Lithops runtime already deployed, and ready to be used in consequent computations |
 
-
-## Summary of configuration keys for Standalone
+### Summary of configuration keys for Standalone
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
@@ -204,5 +201,5 @@ fexec = lithops.FunctionExecutor(monitoring='rabbitmq')
 |standalone | auto_dismantle | True |no | If False then the VM is not stopped automatically. Run **exec.dismantle()** explicitly to stop the VM. |
 |standalone | soft_dismantle_timeout | 300 |no| Time in seconds to stop the VM instance after a job **completed** its execution |
 |standalone | hard_dismantle_timeout | 3600 | no | Time in seconds to stop the VM instance after a job **started** its execution |
-|standalone | exec_mode | consume | no | If set to  **create** standalone backend will automatically create VMs based on the standalone backend|
-|standalone | pull_runtime | false | no | If set to true, lithops will execute the command `docker pull <runtime_name>` in each VSI before execution the a job|
+|standalone | exec_mode | consume | yes | If set to  **create**, Lithops will automatically create VMs based on iterdata|
+|standalone | pull_runtime | False | no | If set to True, Lithops will execute the command `docker pull <runtime_name>` in each VSI before executing the a job|

--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -1,9 +1,9 @@
-lithops: 
+#lithops: 
+    #mode: serverless
     #storage: ibm_cos
     #storage_bucket: <BUCKET_NAME>
-    #mode: serverless
-    #monitoring: storage
     #data_cleaner: <True/False>
+    #monitoring: storage
     #workers: <MAX_NUM_OF_WORKERS>
     #data_limit: 4  # in MiB
     #execution_timeout: 1800
@@ -13,13 +13,14 @@ lithops:
     #log_format: "%(asctime)s [%(levelname)s] %(name)s -- %(message)s"
     #log_stream: ext://sys.stdout
     #log_filename <path_to_a_file>
-    
+
+#localhost:
+    #runtime: python3
+
 #serverless:
     #backend: ibm_cf
-    #runtime : <RUNTIME_NAME>
-    #runtime_timeout: 600
-    #runtime_memory: 256
     #remote_invoker: <True/False>
+    #customized_runtime: <True/False>
 
 #standalone:
     #backend: ibm_vpc
@@ -34,18 +35,28 @@ lithops:
     #iam_api_key: <IAM KEY>
 
 #ibm_cf:
-    #endpoint    : <REGION_ENDPOINT>
-    #namespace   : <NAMESPACE>
-    #api_key     : <API_KEY>
+    #endpoint : <REGION_ENDPOINT>
+    #namespace : <NAMESPACE>
+    #api_key : <API_KEY>
     #namespace_id : <NAMESPACE_ID> # Only for IAM auth
-    #runtime: <RUNTIME_NAME>
+    #runtime : <RUNTIME_NAME>
+    #runtime_timeout: 600
+    #runtime_memory: 256
 
 #code_engine:
-    #kubectl_config: <Location for kubectl yaml file>
-    #runtime: <RUNTIME_NAME>
+    #namespace: <namespace id>
+    #region: <namespace region>
+    #docker_server: <registry server url>
+    #docker_user: <registry username>
+    #docker_password: <registry password>
+    #kubecfg_path: <Location for kubectl yaml file>
+    #runtime : <RUNTIME_NAME>
+    #runtime_timeout: 600
+    #runtime_memory: 256
+    #runtime_cpu : 0.125
 
 #ibm_cos:
-    region : <REGION>
+    #region : <REGION>
     #endpoint    : <REGION_ENDPOINT>
     #private_endpoint: <PRIVATE_REGION_ENDPOINT>
     #api_key     : <API_KEY>
@@ -53,24 +64,18 @@ lithops:
     #secret_key : <SECRET_KEY>  # Optional
 
 #ibm_vpc:
-    #endpoint    : <REGION_ENDPOINT> # https://eu-de.iaas.cloud.ibm.com
-    #instance_id : <INSTANCE_ID>  # Optional
-    #ip_address  : <FLOATING_IP_ADDRESS>
-    #version     : <VPC_VERSION>
-    #generation  : <VPC_GENERATION>
-    #ssh_user    : <SSH_USERNAME>
-    #ssh_key_filename: <SSH_PASSWORD>
+    #endpoint: <REGION_ENDPOINT>
+    #vpc_id: <VPC_ID>
+    #resource_group_id: <RESOURCE_GROUP_ID>
     #security_group_id: <SECURITY_GROUP_ID>
     #subnet_id: <SUBNET_ID>
     #key_id: <PUBLIC_KEY_ID>
-    #resource_group_id: <RESOURCE_GROUP_ID>
-    #vpc_id: <VPC_ID>
-    #image_id: <IMAGE_ID>
-    #custom_lithops_image: <True/False> # Optional
-    #zone_name: <ZONE_NAME>
-    #volume_tier_name: <VOLUME_TIER_NAME>  # Optional
-    #profile_name: <PROFILE_NAME>  # Optional
-    #delete_on_dismantle: False  # Optional
+    #image_id: <IMAGE_ID_FOR_VMs> # Default is ubuntu 20.04
+    #ssh_user : <SSH_USER_FOR_VPC> # Default is 'root'
+    #ssh_key_filename : <PATH_TO_SSH_KEYFILE> # Default path in OS
+    #profile_name: <PROFILE_NAME> # Default is 'cx2-2x4'
+    #master_profile_name:  <PROFILE_NAME> # Default is 'cx2-2x4'
+    #delete_on_dismantle: <True/False> # Default is 'True
 
 #vm:
     #ip_address: <IP_ADDRESS>
@@ -85,18 +90,18 @@ lithops:
    #docker_user     : <DOCKER_HUB_USERNAME>
    #docker_token    : <DOCKER_HUB_TOKEN>
    #runtime: <RUNTIME_NAME>
-
-#docker:
-    #host: <HOST_IP>
-    #ssh_user: <SSH_USER>
-    #ssh_password: <SSH_PASSWORD>
+   #runtime_timeout: 600
+   #runtime_memory: 256
+   #runtime_cpu : 0.125
 
 #openwhisk:
     #endpoint    : <OW_ENDPOINT>
     #namespace   : <NAMESPACE>
     #api_key     : <AUTH_KEY>
     #insecure    : <True/False>
-    #runtime: <RUNTIME_NAME>
+    #runtime : <RUNTIME_NAME>
+    #runtime_timeout: 600
+    #runtime_memory: 256
 
 #swift:
     #auth_url   : <SWIFT_AUTH_URL>
@@ -120,4 +125,3 @@ lithops:
     #host: <ENDPOINT_URL>
     #port: <ACCESS_KEY>
     #password: <ACCESS_KEY>
-    

--- a/docs/function_chaining.md
+++ b/docs/function_chaining.md
@@ -1,0 +1,94 @@
+Lithops Function chaining (beta)
+===================
+
+- Note: This API is beta and may be revised in future releases. If you encounter any bugs, please open an issue on GitHub.
+
+Function chaining is a pattern where multiple functions are called on the same executor consecutively. Using the same `lithops.FunctionExecutor` object reference, multiple functions can be invoked. It increases the readability of the code and means less redundancy. This means we chain multiple functions together with the same element reference. It’s not necessary to attach the `lithops.FunctionExecutor` reference multiple times for each function call.
+
+This patter is specially useful when the output of one invocation is the input of another invocation. In this case, Lithops does not download the intermediate results to the local client, instead, the intermediate results are directly read from the next function.
+
+It currently works with the [Futures API](api_futures.md), and you can chain the `map()`, `map_reuce()`, `wait()` and `get_result()` methods. View the next examples:
+
+
+Getting the result from a single `map()` call:
+
+```python
+import lithops
+
+def my_func1(x):
+    return x*2
+
+iterdata = [1, 2, 3]
+
+fexec = lithops.FunctionExecutor()
+res = fexec.map(my_func1, iterdata).get_result()
+print(res)
+```
+
+
+Chain multiple map() calls and get the final result:
+
+```python
+import lithops
+
+
+def my_func1(x):
+    return x*2, 5
+    
+def my_func2(x, y):
+    return x+y
+
+iterdata = [1, 2, 3]
+
+fexec = lithops.FunctionExecutor()
+res = fexec.map(my_func1, iterdata).map(my_func2).get_result()
+print(res)
+```
+
+There is no limit in the number of map() calls than can be chained:
+
+```python
+def my_func1(x):
+    return x+2, 5
+
+
+def my_func2(x, y):
+    return x+y, 5, 2
+
+
+def my_func3(x, y, z):
+    return x+y+z
+
+
+iterdata = [1, 2, 3]
+
+fexec = lithops.FunctionExecutor()
+res = fexec.map(my_func1, data).map(my_func2).map(my_func3).get_result()
+print(res)
+```
+
+Alternatively, you can pass the `futures` generated in a `map()` or `map_reduce()` call to the `iterdata` parameter with the same effect:
+
+```python
+def my_func1(x):
+    return x+2, 5
+
+
+def my_func2(x, y):
+    return x+y, 5, 2
+
+
+def my_func3(x, y, z):
+    return x+y+z
+
+
+iterdata = [1, 2, 3]
+
+fexec = lithops.FunctionExecutor()
+futures1 = fexec.map(my_func1, iterdata)
+futures2 = fexec.map(my_func2, futures1)
+futures3 = fexec.map(my_func3, futures2)
+final_result = fexec.get_result(futures3)
+
+print(final_result)
+```

--- a/docs/function_chaining.md
+++ b/docs/function_chaining.md
@@ -7,7 +7,7 @@ Function chaining is a pattern where multiple functions are called on the same e
 
 This patter is specially useful when the output of one invocation is the input of another invocation. In this case, Lithops does not download the intermediate results to the local client, instead, the intermediate results are directly read from the next function.
 
-It currently works with the [Futures API](api_futures.md), and you can chain the `map()`, `map_reuce()`, `wait()` and `get_result()` methods. View the next examples:
+It currently works with the [Futures API](api_futures.md), and you can chain the `map()`, `map_reuce()`, `wait()` and `get_result()` methods. Note that the returning value of one function must match the signature of the next function when chaining multiple `map()` calls. View the next examples:
 
 
 Getting the result from a single `map()` call:
@@ -45,7 +45,7 @@ res = fexec.map(my_func1, iterdata).map(my_func2).get_result()
 print(res)
 ```
 
-There is no limit in the number of map() calls than can be chained:
+There is no limit in the number of map() calls that can be chained:
 
 ```python
 def my_func1(x):
@@ -63,7 +63,7 @@ def my_func3(x, y, z):
 iterdata = [1, 2, 3]
 
 fexec = lithops.FunctionExecutor()
-res = fexec.map(my_func1, data).map(my_func2).map(my_func3).get_result()
+res = fexec.map(my_func1, iterdata).map(my_func2).map(my_func3).get_result()
 print(res)
 ```
 

--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -100,7 +100,6 @@ class FunctionExecutor:
             config_ow['lithops']['workers'] = workers
         if monitoring is not None:
             config_ow['lithops']['monitoring'] = monitoring
-        
 
         self.config = default_config(copy.deepcopy(config), config_ow)
 

--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -36,12 +36,14 @@ from lithops.config import default_config, \
 from lithops.constants import LOCALHOST, CLEANER_DIR, \
     CLEANER_LOG_FILE, SERVERLESS, STANDALONE
 from lithops.utils import is_notebook, setup_lithops_logger, \
-    is_lithops_worker, create_executor_id, get_mode, get_backend
+    is_lithops_worker, create_executor_id, get_mode, get_backend,\
+    create_futures_list
 from lithops.localhost.localhost import LocalhostHandler
 from lithops.standalone.standalone import StandaloneHandler
 from lithops.serverless.serverless import ServerlessHandler
 from lithops.storage.utils import create_job_key
 from lithops.monitor import JobMonitor
+from lithops.utils import FuturesList
 
 
 logger = logging.getLogger(__name__)
@@ -143,7 +145,7 @@ class FunctionExecutor:
                                       self.job_monitor)
 
         logger.info('Function executor for {} created with ID: {}'
-                    .format(backend, self.executor_id))
+                    .format(self.config['lithops']['backend'], self.executor_id))
 
         self.log_path = None
 
@@ -234,6 +236,9 @@ class FunctionExecutor:
         job_id = self._create_job_id('M')
         self.last_call = 'map'
 
+        if isinstance(map_iterdata, FuturesList):
+            self.wait(map_iterdata)
+
         runtime_meta = self.invoker.select_runtime(job_id, runtime_memory)
 
         job = create_map_job(config=self.config,
@@ -260,7 +265,7 @@ class FunctionExecutor:
         futures = self.invoker.run_job(job)
         self.futures.extend(futures)
 
-        return futures
+        return create_futures_list(futures, self)
 
     def map_reduce(self, map_function, map_iterdata, reduce_function, chunksize=None,
                    worker_processes=None, extra_args=None, extra_env=None,
@@ -299,6 +304,9 @@ class FunctionExecutor:
         self.last_call = 'map_reduce'
         map_job_id = self._create_job_id('M')
 
+        if isinstance(map_iterdata, FuturesList):
+            self.wait(map_iterdata)
+
         runtime_meta = self.invoker.select_runtime(map_job_id, map_runtime_memory)
 
         map_job = create_map_job(config=self.config,
@@ -326,7 +334,7 @@ class FunctionExecutor:
         self.futures.extend(map_futures)
 
         if reducer_wait_local:
-            wait(fs=map_futures, internal_storage=self.internal_storage, job_monitor=self.job_monitor)
+            self.wait(map_futures)
 
         reduce_job_id = map_job_id.replace('M', 'R')
 
@@ -352,7 +360,7 @@ class FunctionExecutor:
         for f in map_futures:
             f._produce_output = False
 
-        return map_futures + reduce_futures
+        return create_futures_list(map_futures + reduce_futures, self)
 
     def wait(self, fs=None, throw_except=True, return_when=ALL_COMPLETED,
              download_results=False, timeout=None, threadpool_size=THREADPOOL_SIZE,
@@ -379,7 +387,7 @@ class FunctionExecutor:
         :rtype: 2-tuple of list
         """
         futures = fs or self.futures
-        if type(futures) != list:
+        if type(futures) != list and type(futures) != FuturesList:
             futures = [futures]
 
         # Start waiting for results
@@ -416,7 +424,7 @@ class FunctionExecutor:
             fs_done = [f for f in futures if f.success or f.done]
             fs_notdone = [f for f in futures if not f.success and not f.done]
 
-        return fs_done, fs_notdone
+        return create_futures_list(fs_done, self), create_futures_list(fs_notdone, self)
 
     def get_result(self, fs=None, throw_except=True, timeout=None,
                    threadpool_size=THREADPOOL_SIZE, wait_dur_sec=WAIT_DUR_SEC):

--- a/lithops/future.py
+++ b/lithops/future.py
@@ -25,6 +25,7 @@ import pickle
 import logging
 import traceback
 from six import reraise
+
 from lithops.storage import InternalStorage
 from lithops.storage.utils import check_storage_path, get_storage_path,\
     create_job_key

--- a/lithops/job/serialize.py
+++ b/lithops/job/serialize.py
@@ -63,7 +63,7 @@ class SerializeIndependent:
             if module_name == '__main__':
                 continue
             origin = importlib.util.find_spec(module_name).origin
-            direct_modules.add(origin if origin != 'built-in' else module_name)
+            direct_modules.add(origin if origin not in ['built-in', None] else module_name)
             self._modulemgr.add(module_name)
 
         logger.debug("Referenced modules: {}".format(None if not direct_modules

--- a/lithops/monitor.py
+++ b/lithops/monitor.py
@@ -286,16 +286,22 @@ class StorageMonitor(Monitor):
             else:
                 return None
 
-        pool = cf.ThreadPoolExecutor(max_workers=self.THREADPOOL_SIZE)
-        call_ids_processed = set(pool.map(get_status, fs_to_query))
-        pool.shutdown()
+        try:
+            pool = cf.ThreadPoolExecutor(max_workers=self.THREADPOOL_SIZE)
+            call_ids_processed = set(pool.map(get_status, fs_to_query))
+            pool.shutdown()
+        except Exception:
+            pass
 
         try:
             call_ids_processed.remove(None)
         except Exception:
             pass
 
-        self.callids_done_processed_status.update(call_ids_processed)
+        try:
+            self.callids_done_processed_status.update(call_ids_processed)
+        except Exception:
+            pass
 
     def _generate_tokens(self, callids_running, callids_done):
         """

--- a/lithops/standalone/master.py
+++ b/lithops/standalone/master.py
@@ -138,7 +138,7 @@ def setup_worker(worker_info, work_queue, job_key):
     script = get_worker_setup_script(STANDALONE_CONFIG, vm_data)
     vm.get_ssh_client().run_remote_command(script, run_async=True)
     vm.del_ssh_client()
-    logger.info('Installation process finished on {}'.format(vm))
+    logger.info('Installation script submitted to {}'.format(vm))
 
 
 def stop_job_process(job_key):

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -144,7 +144,7 @@ class StandaloneHandler:
         total_calls = job_payload['total_calls']
         chunksize = job_payload['chunksize']
 
-        total_workers = total_calls // chunksize + (total_calls % chunksize > 0) \
+        total_workers = workers or total_calls // chunksize + (total_calls % chunksize > 0) \
             if self.exec_mode == 'create' else 1
 
         def start_master_instance(wait=True):
@@ -160,14 +160,13 @@ class StandaloneHandler:
                     worker_id = "{:04d}".format(vm_n)
                     name = 'lithops-{}-{}-{}'.format(executor_id, job_id, worker_id)
                     ex.submit(self.backend.create_worker, name)
-
             logger.debug("Total worker VM instances created: {}/{}"
                          .format(len(self.backend.workers), total_workers))
+            total_workers = len(self.backend.workers)
 
-        logger.debug('ExecutorID {} | JobID {} - Going '
-                     'to run {} activations in {} workers'
-                     .format(executor_id, job_id,
-                             total_calls, len(self.backend.workers)))
+        logger.debug('ExecutorID {} | JobID {} - Going to run {} activations '
+                     'in {} workers'.format(executor_id, job_id, total_calls,
+                                            total_workers))
 
         logger.debug("Checking if {} is ready".format(self.backend.master))
         start_master_instance(wait=True)

--- a/lithops/utils.py
+++ b/lithops/utils.py
@@ -97,25 +97,25 @@ class FuturesList(list):
         from lithops import FunctionExecutor
         self.executor = FunctionExecutor(config=self.config)
 
-    def map(self, map_function):
+    def map(self, map_function, **kwargs):
         if not self.executor:
             self._create_executor()
-        return self.executor.map(map_function, self)
+        return self.executor.map(map_function, self, **kwargs)
 
-    def map_reduce(self, map_function, reduce_function):
+    def map_reduce(self, map_function, reduce_function, **kwargs):
         if not self.executor:
             self._create_executor()
-        return self.executor.map_reduce(map_function, self, reduce_function)
+        return self.executor.map_reduce(map_function, self, reduce_function, **kwargs)
 
-    def wait(self):
+    def wait(self, **kwargs):
         if not self.executor:
             self._create_executor()
-        return self.executor.wait(self)
+        return self.executor.wait(self, **kwargs)
 
-    def get_result(self):
+    def get_result(self, **kwargs):
         if not self.executor:
             self._create_executor()
-        return self.executor.get_result(self)
+        return self.executor.get_result(self, **kwargs)
 
     def __reduce__(self):
         self.executor = None

--- a/lithops/utils.py
+++ b/lithops/utils.py
@@ -425,6 +425,9 @@ def format_data(iterdata, extra_args):
 
 def verify_args(func, iterdata, extra_args):
 
+    if isinstance(iterdata, FuturesList):
+        return [{'future': f} for f in iterdata]
+
     data = format_data(iterdata, extra_args)
 
     # Verify parameters

--- a/lithops/utils.py
+++ b/lithops/utils.py
@@ -69,6 +69,59 @@ def iterchunks(lst, n):
         yield lst[i:i + n]
 
 
+def agg_data(data_strs):
+    """Auxiliary function that aggregates data of a job to a single
+    byte string.
+    """
+    ranges = []
+    pos = 0
+    for datum in data_strs:
+        datum_len = len(datum)
+        ranges.append((pos, pos+datum_len-1))
+        pos += datum_len
+    return b"".join(data_strs), ranges
+
+
+def create_futures_list(futures, executor):
+    """creates a new FuturesList an initiates its attrs"""
+    fl = FuturesList(futures)
+    fl.config = executor.config
+    fl.executor = executor
+
+    return fl
+
+
+class FuturesList(list):
+
+    def _create_executor(self):
+        from lithops import FunctionExecutor
+        self.executor = FunctionExecutor(config=self.config)
+
+    def map(self, map_function):
+        if not self.executor:
+            self._create_executor()
+        return self.executor.map(map_function, self)
+
+    def map_reduce(self, map_function, reduce_function):
+        if not self.executor:
+            self._create_executor()
+        return self.executor.map_reduce(map_function, self, reduce_function)
+
+    def wait(self):
+        if not self.executor:
+            self._create_executor()
+        return self.executor.wait(self)
+
+    def get_result(self):
+        if not self.executor:
+            self._create_executor()
+        return self.executor.get_result(self)
+
+    def __reduce__(self):
+        self.executor = None
+        return super().__reduce__()
+
+
 def get_backend(mode):
     """ Return lithops execution backend """
 
@@ -93,19 +146,6 @@ def get_mode(backend):
         return constants.STANDALONE
     elif backend:
         raise Exception("Unknown compute backend: {}".format(backend))
-
-
-def agg_data(data_strs):
-    """Auxiliary function that aggregates data of a job to a single
-    byte string.
-    """
-    ranges = []
-    pos = 0
-    for datum in data_strs:
-        datum_len = len(datum)
-        ranges.append((pos, pos+datum_len-1))
-        pos += datum_len
-    return b"".join(data_strs), ranges
 
 
 def setup_lithops_logger(log_level=constants.LOGGER_LEVEL,
@@ -355,7 +395,7 @@ def format_data(iterdata, extra_args):
     # Format iterdata in a proper way
     if type(iterdata) in [range, set]:
         data = list(iterdata)
-    elif type(iterdata) != list:
+    elif type(iterdata) != list and type(iterdata) != FuturesList:
         data = [iterdata]
     else:
         data = iterdata

--- a/lithops/wait.py
+++ b/lithops/wait.py
@@ -19,11 +19,13 @@ import logging
 import time
 import concurrent.futures as cf
 from functools import partial
-from lithops.utils import is_unix_system, timeout_handler, is_notebook, is_lithops_worker
+from lithops.utils import is_unix_system, timeout_handler, \
+    is_notebook, is_lithops_worker, FuturesList
 from lithops.storage import InternalStorage
 from lithops.monitor import JobMonitor
 from types import SimpleNamespace
 from itertools import chain
+
 
 ALL_COMPLETED = 1
 ANY_COMPLETED = 2
@@ -62,7 +64,7 @@ def wait(fs, internal_storage=None, throw_except=True, timeout=None,
     if not fs:
         return
 
-    if type(fs) != list:
+    if type(fs) != list and type(fs) != FuturesList:
         fs = [fs]
 
     if download_results:
@@ -177,7 +179,7 @@ def get_result(fs, throw_except=True, timeout=None,
     :param WAIT_DUR_SEC: Time interval between each check.
     :return: The result of the future/s
     """
-    if type(fs) != list:
+    if type(fs) != list and type(fs) != FuturesList:
         fs = [fs]
 
     fs_done, _ = wait(fs=fs, throw_except=throw_except,

--- a/lithops/wait.py
+++ b/lithops/wait.py
@@ -110,8 +110,7 @@ def wait(fs, internal_storage=None, throw_except=True, timeout=None,
                     new_data = _get_job_data(fs, job_data, pbar=pbar,
                                              throw_except=throw_except,
                                              download_results=download_results,
-                                             threadpool_size=threadpool_size,
-                                             job_monitor=job_monitor)
+                                             threadpool_size=threadpool_size)
                 time.sleep(0 if new_data else sleep_sec)
 
         elif return_when == ANY_COMPLETED:
@@ -120,8 +119,7 @@ def wait(fs, internal_storage=None, throw_except=True, timeout=None,
                     new_data = _get_job_data(fs, job_data, pbar=pbar,
                                              throw_except=throw_except,
                                              download_results=download_results,
-                                             threadpool_size=threadpool_size,
-                                             job_monitor=job_monitor)
+                                             threadpool_size=threadpool_size)
                 time.sleep(0 if new_data else sleep_sec)
 
         elif return_when == ALWAYS:
@@ -129,8 +127,7 @@ def wait(fs, internal_storage=None, throw_except=True, timeout=None,
                 _get_job_data(fs, job_data, pbar=pbar,
                               throw_except=throw_except,
                               download_results=download_results,
-                              threadpool_size=threadpool_size,
-                              job_monitor=job_monitor)
+                              threadpool_size=threadpool_size)
 
     except KeyboardInterrupt as e:
         if download_results:
@@ -246,7 +243,7 @@ def _any_done(fs, download_results):
         return any([f.success or f.done for f in fs])
 
 
-def _get_job_data(fs, job_data, download_results, throw_except, threadpool_size, pbar, job_monitor):
+def _get_job_data(fs, job_data, download_results, throw_except, threadpool_size, pbar):
     """
     Downloads all status/results from ready futures
     """

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -32,7 +32,7 @@ from distutils.util import strtobool
 from lithops.storage import Storage
 from lithops.wait import wait
 from lithops.future import ResponseFuture
-from lithops.utils import sizeof_fmt, is_object_processing_function
+from lithops.utils import sizeof_fmt, is_object_processing_function, verify_args
 from lithops.utils import WrappedStreamingBodyPartition
 from lithops.util.metrics import PrometheusExporter
 from lithops.storage.utils import create_output_key
@@ -79,6 +79,10 @@ class JobRunner:
         Fills in those reserved, optional parameters that might be write to the function signature
         """
         func_sig = inspect.signature(function)
+
+        if len(data) == 1 and 'future' in data:
+            out = [data.pop('future').result()]
+            data.update(verify_args(function, out, None)[0])
 
         if 'ibm_cos' in func_sig.parameters:
             if 'ibm_cos' in self.lithops_config:


### PR DESCRIPTION
This PR enables the function chaining pattern in the Futures API. This is especially useful when the output of one function invocation is the input of another function invocation. With this, results from one function invocation are never downloaded to the local client, but directly get from the next function, unless you explicitly call the `get_result()` method.

With this, you can code with Lithops like this:

```python
import lithops

def my_func1(x):
    return x*2, 5
    
def my_func2(x, y):
    return x+y

iterdata = [1, 2, 3]

fexec = lithops.FunctionExecutor()
res = fexec.map(my_func1, iterdata).map(my_func2).get_result()
print(res)
```

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

