### PR TITLE
[AWS Lambda] Get pre-built numpy layer instead of compile locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
 
-## [v2.3.6.devX]
+## [v2.3.6.dev0]
 
 ### Added
 - 
 
 ### Changed
-- 
+- [AWS Lambda] Use layer from Klayers API for pre-compiled Amazon Linux numpy binaries
 
 ### Fixes
 - [Localhost] Fixed error when processing localhost objects

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -26,7 +26,6 @@ DEFAULT_REQUIREMENTS = [
     'requests',
     'redis',
     'pika',
-    'numpy',
     'cloudpickle',
     'ps-mem',
     'tblib'


### PR DESCRIPTION
- Uses public pre-built layer from [Klayers](https://github.com/keithrozario/Klayers) for numpy instead of using binaries compiled locally. Fixes issue in #694, where a host using Windows or Mac OS will use compiled numpy Windows/MacOS while lambda uses Amazon Linux.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

