### PR TITLE
Improve performance and efficiency of call_async() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
 
-## [v2.3.6.dev0]
+## [v2.3.6.dev1]
 
 ### Added
 - [Storage] Added MinIO storage backend
 - [Core] Allow to pass function args as part of the invocation payload in FaaS backends
-- [Core] Optimize call_async() calls with an internal function cache system
+- [Core] Optimize call_async() calls with an internal function caching system
 
 ### Changed
+- [Core] Improved performance and efficiency of the lithops cleaner background process
 - [AWS Lambda] Use layer from Klayers API for pre-compiled Amazon Linux numpy binaries
 
 ### Fixes
@@ -19,6 +20,7 @@
 - [Core] Fixed get_result() execution after wait() when throw_except is set to False
 - [Core] Fixed internal executions
 - [Core] Fixed 'lithops storage list' CLI when a bucket is empty
+- [Standalone] Fixed execution
 
 ### Deleted
 - [Core] Deleted invoke_pool_threads param from map and map_reduce calls. Now it must be set at backend level in config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [v2.3.6.dev1]
+## [v2.3.6.dev0]
 
 ### Added
 - [Storage] Added MinIO storage backend

--- a/lithops/invokers.py
+++ b/lithops/invokers.py
@@ -452,7 +452,9 @@ class FaaSInvoker(Invoker):
         Run a job
         """
         futures = self._run_job(job)
-        self.job_monitor.start(futures, generate_tokens=True)
+        self.job_monitor.start(futures, job_id=job.job_id,
+                               chunksize=job.chunksize,
+                               generate_tokens=True)
 
         return futures
 

--- a/lithops/invokers.py
+++ b/lithops/invokers.py
@@ -452,9 +452,12 @@ class FaaSInvoker(Invoker):
         Run a job
         """
         futures = self._run_job(job)
-        self.job_monitor.start(futures, job_id=job.job_id,
-                               chunksize=job.chunksize,
-                               generate_tokens=True)
+        self.job_monitor.start(
+            fs=futures,
+            job_id=job.job_id,
+            chunksize=job.chunksize,
+            generate_tokens=True
+        )
 
         return futures
 

--- a/lithops/invokers.py
+++ b/lithops/invokers.py
@@ -251,9 +251,8 @@ class BatchInvoker(Invoker):
         """
         Run a job
         """
-        job_monitor = self.job_monitor.create(job, self.internal_storage)
         futures = self._run_job(job)
-        job_monitor.start()
+        self.job_monitor.start(futures)
 
         return futures
 
@@ -452,9 +451,8 @@ class FaaSInvoker(Invoker):
         """
         Run a job
         """
-        job_monitor = self.job_monitor.create(job, self.internal_storage, generate_tokens=True)
         futures = self._run_job(job)
-        job_monitor.start()
+        self.job_monitor.start(futures, generate_tokens=True)
 
         return futures
 

--- a/lithops/job/job.py
+++ b/lithops/job/job.py
@@ -240,7 +240,7 @@ def _create_job(config, internal_storage, executor_id, job_id, func,
             FUNCTION_CACHE.add(job.func_key)
         else:
             logger.debug('ExecutorID {} | JobID {} - Function and modules '
-                         'in cache'.format(executor_id, job_id))
+                         'found in local cache'.format(executor_id, job_id))
             host_job_meta['host_func_upload_time'] = 0
 
     else:

--- a/lithops/monitor.py
+++ b/lithops/monitor.py
@@ -339,16 +339,12 @@ class StorageMonitor(Monitor):
         callids_done_to_process = callids_done - self.callids_done_processed
 
         for call_id, worker_id in callids_running_to_process:
-            if call_id[1] not in self.present_jobs:
-                continue
             if worker_id not in self.workers:
                 self.workers[worker_id] = set()
             self.workers[worker_id].add(call_id)
             self.callids_running_worker[call_id] = worker_id
 
         for callid_done in callids_done_to_process:
-            if callid_done[1] not in self.present_jobs:
-                continue
             if callid_done in self.callids_running_worker:
                 worker_id = self.callids_running_worker[callid_done]
                 if worker_id not in self.callids_done_worker:
@@ -357,6 +353,8 @@ class StorageMonitor(Monitor):
 
         for worker_id in self.callids_done_worker:
             job_id = self.callids_done_worker[worker_id][0][1]
+            if job_id not in self.present_jobs:
+                continue
             chunksize = self.job_chunksize[job_id]
             if worker_id not in self.workers_done and \
                len(self.callids_done_worker[worker_id]) == chunksize:

--- a/lithops/monitor.py
+++ b/lithops/monitor.py
@@ -36,15 +36,22 @@ class Monitor(threading.Thread):
     """
     Monitor base class
     """
-    def __init__(self, job, internal_storage, token_bucket_q, generate_tokens, config):
+    def __init__(self, executor_id,
+                 internal_storage,
+                 token_bucket_q,
+                 generate_tokens,
+                 config):
+
         super().__init__()
-        self.job = job
+        self.executor_id = executor_id
+        self.futures = []
         self.internal_storage = internal_storage
         self.should_run = True
         self.token_bucket_q = token_bucket_q
         self.generate_tokens = generate_tokens
         self.config = config
         self.daemon = True
+        self.lock = True
 
         # vars for _generate_tokens
         self.workers = {}
@@ -55,7 +62,7 @@ class Monitor(threading.Thread):
         """
         Checks if all futures are ready, success or done
         """
-        return all([f.ready or f.success or f.done for f in self.job.futures])
+        return all([f.ready or f.success or f.done for f in self.futures])
 
     def _check_new_futures(self, call_status, f):
         """Checks if a functions returned new futures to track"""
@@ -63,9 +70,8 @@ class Monitor(threading.Thread):
             return False
 
         f._set_futures(call_status)
-        self.job.futures.extend(f._new_futures)
-        logger.debug('ExecutorID {} | JobID {} - Got {} new futures to track'
-                     .format(self.job.executor_id, self.job.job_id, len(f._new_futures)))
+        self.futures.extend(f._new_futures)
+        logger.debug(f'ExecutorID {self.executor_id} - Got {len(f._new_futures)} new futures to track')
 
         return True
 
@@ -96,12 +102,11 @@ class Monitor(threading.Thread):
 
     def _print_status_log(self):
         """prints a debug log showing the status of the job"""
-        callids_pending = len([f for f in self.job.futures if f.invoked])
-        callids_running = len([f for f in self.job.futures if f.running])
-        callids_done = len([f for f in self.job.futures if f.ready or f.success or f.done])
-        logger.debug('ExecutorID {} | JobID {} - Pending: {} - Running: {} - Done: {}'
-                     .format(self.job.executor_id, self.job.job_id,
-                             callids_pending, callids_running, callids_done))
+        callids_pending = len([f for f in self.futures if f.invoked])
+        callids_running = len([f for f in self.futures if f.running])
+        callids_done = len([f for f in self.futures if f.ready or f.success or f.done])
+        logger.debug(f'ExecutorID {self.executor_id} - Pending: {callids_pending} '
+                     f'- Running: {callids_running} - Done: {callids_done}')
 
 
 class RabbitmqMonitor(Monitor):
@@ -110,7 +115,7 @@ class RabbitmqMonitor(Monitor):
         super().__init__(job, internal_storage, token_bucket_q, generate_tokens, config)
 
         self.rabbit_amqp_url = config.get('amqp_url')
-        self.queue = 'lithops-{}'.format(self.job.job_key)
+        self.queue = f'lithops-{self.executor_id}'
         self._create_resources()
 
     def _create_resources(self):
@@ -147,7 +152,7 @@ class RabbitmqMonitor(Monitor):
         """
         Assigns a call_status to its future
         """
-        not_running_futures = [f for f in self.job.futures if not (f.running or f.ready or f.success or f.done)]
+        not_running_futures = [f for f in self.futures if not (f.running or f.ready or f.success or f.done)]
         for f in not_running_futures:
             calljob_id = (call_status['executor_id'], call_status['job_id'], call_status['call_id'])
             if (f.executor_id, f.job_id, f.call_id) == calljob_id:
@@ -157,7 +162,7 @@ class RabbitmqMonitor(Monitor):
         """
         tags a future as ready based on call_status
         """
-        not_ready_futures = [f for f in self.job.futures if not (f.ready or f.success or f.done)]
+        not_ready_futures = [f for f in self.futures if not (f.ready or f.success or f.done)]
         for f in not_ready_futures:
             calljob_id = (call_status['executor_id'], call_status['job_id'], call_status['call_id'])
             if (f.executor_id, f.job_id, f.call_id) == calljob_id:
@@ -184,8 +189,8 @@ class RabbitmqMonitor(Monitor):
                 self.token_bucket_q.put('#')
 
     def run(self):
-        logger.debug('ExecutorID {} | JobID {} - Starting RabbitMQ job monitor'
-                     .format(self.job.executor_id, self.job.job_id))
+        logger.debug('ExecutorID {} |  Starting RabbitMQ job monitor'
+                     .format(self.executor_id))
         channel = self.connection.channel()
 
         def callback(ch, method, properties, body):
@@ -202,17 +207,20 @@ class RabbitmqMonitor(Monitor):
                 ch.stop_consuming()
                 ch.close()
                 self._print_status_log()
-                logger.debug('ExecutorID {} | JobID {} - RabbitMQ job monitor finished'
+                logger.debug('ExecutorID {} | RabbitMQ job monitor finished'
                              .format(self.job.executor_id, self.job.job_id))
 
         channel.basic_consume(self.queue, callback, auto_ack=True)
         threading.Thread(target=channel.start_consuming, daemon=True).start()
 
-        while not self._all_ready() and self.should_run:
+        while not self._all_ready() or not self.futures:
             # Format call_ids running, pending and done
             self._print_status_log()
-            self._future_timeout_checker(self.job.futures)
+            self._future_timeout_checker(self.futures)
             time.sleep(2)
+
+            if not self.should_run:
+                break
 
 
 class StorageMonitor(Monitor):
@@ -220,8 +228,8 @@ class StorageMonitor(Monitor):
     THREADPOOL_SIZE = 64
     WAIT_DUR_SEC = 2  # Check interval
 
-    def __init__(self, job, internal_storage, token_bucket_q, generate_tokens, config):
-        super().__init__(job, internal_storage, token_bucket_q, generate_tokens, config)
+    def __init__(self, executor_id, internal_storage, token_bucket_q, generate_tokens, config):
+        super().__init__(executor_id, internal_storage, token_bucket_q, generate_tokens, config)
 
         # vars for _generate_tokens
         self.callids_running_worker = {}
@@ -245,7 +253,7 @@ class StorageMonitor(Monitor):
         Mark which futures are in running status based on callids_running
         """
         current_time = time.time()
-        not_running_futures = [f for f in self.job.futures if not (f.running or f.ready or f.success or f.done)]
+        not_running_futures = [f for f in self.futures if not (f.running or f.ready or f.success or f.done)]
         callids_running_to_process = callids_running - self.callids_running_processed_timeout
         for f in not_running_futures:
             for call in callids_running_to_process:
@@ -256,18 +264,18 @@ class StorageMonitor(Monitor):
                     f._set_running(call_status)
 
         self.callids_running_processed_timeout.update(callids_running_to_process)
-        self._future_timeout_checker(self.job.futures)
+        self._future_timeout_checker(self.futures)
 
     def _tag_future_as_ready(self, callids_done):
         """
         Mark which futures has a call_status ready to be downloaded
         """
-        not_ready_futures = [f for f in self.job.futures if not (f.ready or f.success or f.done)]
+        not_ready_futures = [f for f in self.futures if not (f.ready or f.success or f.done)]
         callids_done_to_process = callids_done - self.callids_done_processed_status
         fs_to_query = []
 
-        ten_percent = int(len(self.job.futures) * (10 / 100))
-        if len(self.job.futures) - len(callids_done) <= max(10, ten_percent):
+        ten_percent = int(len(self.futures) * (10 / 100))
+        if len(self.futures) - len(callids_done) <= max(10, ten_percent):
             fs_to_query = not_ready_futures
         else:
             for f in not_ready_futures:
@@ -328,7 +336,7 @@ class StorageMonitor(Monitor):
 
         for worker_id in self.callids_done_worker:
             if worker_id not in self.workers_done and \
-               len(self.callids_done_worker[worker_id]) == self.job.chunksize:
+               len(self.callids_done_worker[worker_id]) == 1:
                 self.workers_done.append(worker_id)
                 if self.should_run:
                     self.token_bucket_q.put('#')
@@ -342,14 +350,17 @@ class StorageMonitor(Monitor):
         """
         Run method
         """
-        logger.debug('ExecutorID {} | JobID {} - Starting Storage job monitor'
-                     .format(self.job.executor_id, self.job.job_id))
+        logger.debug(f'ExecutorID {self.executor_id} - Starting Storage job monitor')
 
-        while self.should_run and not self._all_ready():
+        while not self._all_ready() or not self.futures:
+            time.sleep(self.WAIT_DUR_SEC)
+            self.WAIT_DUR_SEC = 2
+
             if not self.should_run:
                 break
+
             callids_running, callids_done = \
-                self.internal_storage.get_job_status(self.job.executor_id, self.job.job_id)
+                self.internal_storage.get_job_status(self.executor_id)
 
             # verify if there are new callids_done and reduce the sleep
             new_callids_done = callids_done - self.callids_done_processed_status
@@ -362,64 +373,36 @@ class StorageMonitor(Monitor):
             self._tag_future_as_ready(callids_done)
             self._print_status_log()
 
-            if not self._all_ready():
-                time.sleep(self.WAIT_DUR_SEC)
-                self.WAIT_DUR_SEC = 2
-
-        logger.debug('ExecutorID {} | JobID {} - Storage job monitor finished'
-                     .format(self.job.executor_id, self.job.job_id))
+        logger.debug(f'ExecutorID {self.executor_id} - Storage job monitor finished')
 
 
 class JobMonitor:
 
-    def __init__(self, backend, config=None):
+    def __init__(self, executor_id, internal_storage, backend, config=None):
+        self.executor_id = executor_id
+        self.internal_storage = internal_storage
         self.backend = backend
         self.config = config
-        self.monitors = {}
         self.token_bucket_q = queue.Queue()
+        self.monitor = None
 
-    def stop(self, job_keys=None):
-        """
-        Stops job monitors
-        """
-        if job_keys:
-            for job_key in job_keys:
-                if job_key in self.monitors:
-                    if self.monitors[job_key].is_alive():
-                        self.monitors[job_key].stop()
-                    del self.monitors[job_key]
-        else:
-            # Stop all
-            for job_key in self.monitors:
-                if self.monitors[job_key].is_alive():
-                    self.monitors[job_key].stop()
-            self.monitors = {}
+        self.MonitorClass = getattr(
+            lithops.monitor,
+            f'{self.backend.capitalize()}Monitor'
+        )
 
-    def is_alive(self, job_key):
-        """
-        Checks if a job monitor is alive
-        """
-        if job_key not in self.monitors:
-            return False
-        return self.monitors[job_key].is_alive()
+    def start(self, fs, generate_tokens=False):
+        if not self.monitor or not self.monitor.is_alive():
+            self.monitor = self.MonitorClass(
+                executor_id=self.executor_id,
+                internal_storage=self.internal_storage,
+                token_bucket_q=self.token_bucket_q,
+                generate_tokens=generate_tokens,
+                config=self.config
+            )
+            self.monitor.start()
+        self.monitor.futures.extend(fs)
 
-    def get_active_jobs(self):
-        """
-        Returns a list of active job monitors
-        """
-        active_jobs = 0
-        for job_monitor in self.monitors:
-            if job_monitor.is_alive():
-                active_jobs += 1
-        return active_jobs
-
-    def create(self, job, internal_storage, generate_tokens=False):
-        """
-        Creates a new monitor for a given job
-        """
-        Monitor = getattr(lithops.monitor, '{}Monitor'.format(self.backend.capitalize()))
-        jm = Monitor(job=job, internal_storage=internal_storage,
-                     token_bucket_q=self.token_bucket_q,
-                     generate_tokens=generate_tokens, config=self.config)
-        self.monitors[job.job_key] = jm
-        return jm
+    def stop(self):
+        if self.monitor and self.monitor.is_alive():
+            self.monitor.stop()

--- a/lithops/scripts/cleaner.py
+++ b/lithops/scripts/cleaner.py
@@ -25,61 +25,108 @@ from lithops.storage.utils import clean_bucket
 from lithops.constants import JOBS_PREFIX, TEMP_PREFIX, CLEANER_DIR,\
     CLEANER_PID_FILE, CLEANER_LOG_FILE
 
-logger = logging.getLogger('cleaner')
+logger = logging.getLogger('lithops')
 logging.basicConfig(filename=CLEANER_LOG_FILE, level=logging.INFO,
                     format=('%(asctime)s [%(levelname)s] %(module)s'
-                            ' - %(funcName)s: %(message)s'))
+                            ' [%(threadName)s] - %(funcName)s: %(message)s'))
+logger.setLevel('DEBUG')
+
+
+def clean_executor_jobs(executor_id, executor_data):
+
+    storage = None
+    prefix = '/'.join([JOBS_PREFIX, executor_id])
+    objects_to_delete = []
+
+    for file_data in executor_data:
+        file_location = file_data['file_location']
+        data = file_data['data']
+
+        storage_config = data['storage_config']
+        clean_cloudobjects = data['clean_cloudobjects']
+        if not storage:
+            storage = Storage(storage_config=storage_config)
+
+        logger.info(f'Cleaning jobs {", ".join([job_key for job_key in data["jobs_to_clean"]])}')
+
+        objects = storage.list_keys(storage.bucket, prefix)
+        objects_to_delete = [key for key in objects if key.split('/')[1] in data['jobs_to_clean']]
+        while objects_to_delete:
+            storage.delete_objects(storage.bucket, objects_to_delete)
+            time.sleep(5)
+            objects = storage.list_keys(storage.bucket, prefix)
+            objects_to_delete = [key for key in objects if key.split('/')[1] in data['jobs_to_clean']]
+
+        if clean_cloudobjects:
+            for job_key in data['jobs_to_clean']:
+                prefix = '/'.join([TEMP_PREFIX, job_key])
+                clean_bucket(storage, storage.bucket, prefix)
+
+        if os.path.exists(file_location):
+            os.remove(file_location)
+        logger.info('Finished')
+
+
+def clean_cloudobjects(cloudobjects_data):
+    file_location = cloudobjects_data['file_location']
+    data = cloudobjects_data['data']
+
+    logger.info('Going to clean cloudobjects')
+    cos_to_clean = data['cos_to_clean']
+    storage_config = data['storage_config']
+    storage = Storage(storage_config=storage_config)
+
+    for co in cos_to_clean:
+        if co.backend == storage.backend:
+            logging.info('Cleaning {}://{}/{}'.format(co.backend,
+                                                      co.bucket,
+                                                      co.key))
+            storage.delete_object(co.bucket, co.key)
+
+    if os.path.exists(file_location):
+        os.remove(file_location)
+    logger.info('Finished')
 
 
 def clean():
 
-    def clean_file(file_name):
-        file_location = os.path.join(CLEANER_DIR, file_name)
-
-        if file_location in [CLEANER_LOG_FILE, CLEANER_PID_FILE]:
-            return
-
-        with open(file_location, 'rb') as pk:
-            data = pickle.load(pk)
-
-        if 'jobs_to_clean' in data:
-            jobs_to_clean = data['jobs_to_clean']
-            storage_config = data['storage_config']
-            clean_cloudobjects = data['clean_cloudobjects']
-            storage = Storage(storage_config=storage_config)
-
-            for job_key in jobs_to_clean:
-                logger.info('Going to clean: {}'.format(job_key))
-
-                prefix = '/'.join([JOBS_PREFIX, job_key])
-                clean_bucket(storage, storage.bucket, prefix)
-
-                if clean_cloudobjects:
-                    prefix = '/'.join([TEMP_PREFIX, job_key])
-                    clean_bucket(storage, storage.bucket, prefix)
-
-        if 'cos_to_clean' in data:
-            logger.info('Going to clean cloudobjects')
-            cos_to_clean = data['cos_to_clean']
-            storage_config = data['storage_config']
-            storage = Storage(storage_config=storage_config)
-
-            for co in cos_to_clean:
-                if co.backend == storage.backend:
-                    logging.info('Cleaning {}://{}/{}'.format(co.backend,
-                                                              co.bucket,
-                                                              co.key))
-                    storage.delete_object(co.bucket, co.key)
-
-        if os.path.exists(file_location):
-            os.remove(file_location)
-
     while True:
+        executor_jobs = {}
+        cloudobjects = []
+
         files_to_clean = os.listdir(CLEANER_DIR)
+
         if len(files_to_clean) <= 2:
             break
-        with ThreadPoolExecutor(max_workers=32) as ex:
-            ex.map(clean_file, files_to_clean)
+
+        for file_name in files_to_clean:
+            file_location = os.path.join(CLEANER_DIR, file_name)
+            if file_location in [CLEANER_LOG_FILE, CLEANER_PID_FILE]:
+                continue
+
+            with open(file_location, 'rb') as pk:
+                data = pickle.load(pk)
+
+            if 'jobs_to_clean' in data:
+                # group data by executor_id
+                executor_id, job_id = next(iter(data['jobs_to_clean'])).rsplit('-', 1)
+                if executor_id not in executor_jobs:
+                    executor_jobs[executor_id] = []
+                executor_jobs[executor_id].append({'file_location': file_location, 'data': data})
+
+            elif 'cos_to_clean' in data:
+                cloudobjects.append({'file_location': file_location, 'data': data})
+
+        if executor_jobs:
+            with ThreadPoolExecutor(max_workers=32) as ex:
+                for executor_id in executor_jobs:
+                    ex.submit(clean_executor_jobs, executor_id, executor_jobs[executor_id])
+
+        if cloudobjects:
+            with ThreadPoolExecutor(max_workers=32) as ex:
+                for cloudobjects_data in cloudobjects:
+                    ex.submit(clean_cloudobjects, cloudobjects_data)
+
         time.sleep(5)
 
 

--- a/lithops/scripts/cleaner.py
+++ b/lithops/scripts/cleaner.py
@@ -36,7 +36,6 @@ def clean_executor_jobs(executor_id, executor_data):
 
     storage = None
     prefix = '/'.join([JOBS_PREFIX, executor_id])
-    objects_to_delete = []
 
     for file_data in executor_data:
         file_location = file_data['file_location']
@@ -50,12 +49,21 @@ def clean_executor_jobs(executor_id, executor_data):
         logger.info(f'Cleaning jobs {", ".join([job_key for job_key in data["jobs_to_clean"]])}')
 
         objects = storage.list_keys(storage.bucket, prefix)
-        objects_to_delete = [key for key in objects if key.split('/')[1] in data['jobs_to_clean']]
+        objects_to_delete = [
+                key for key in objects
+                if '-'.join(key.split('/')[1].split('-')[0:3])
+                in data['jobs_to_clean']
+        ]
+
         while objects_to_delete:
             storage.delete_objects(storage.bucket, objects_to_delete)
             time.sleep(5)
             objects = storage.list_keys(storage.bucket, prefix)
-            objects_to_delete = [key for key in objects if key.split('/')[1] in data['jobs_to_clean']]
+            objects_to_delete = [
+                key for key in objects
+                if '-'.join(key.split('/')[1].split('-')[0:3])
+                in data['jobs_to_clean']
+            ]
 
         if clean_cloudobjects:
             for job_key in data['jobs_to_clean']:

--- a/lithops/standalone/master.py
+++ b/lithops/standalone/master.py
@@ -267,7 +267,7 @@ def run():
         pull_runtime = STANDALONE_CONFIG.get('pull_runtime', False)
         try:
             localhost_handler = LocalhostHandler({'runtime': runtime, 'pull_runtime': pull_runtime})
-            localhost_handler.invoke(job_payload, workers=1)
+            localhost_handler.invoke(job_payload)
         except Exception as e:
             logger.error(e)
 

--- a/lithops/standalone/worker.py
+++ b/lithops/standalone/worker.py
@@ -78,7 +78,7 @@ def run_worker(master_ip, job_key):
         pull_runtime = STANDALONE_CONFIG.get('pull_runtime', False)
         try:
             localhost_handler = LocalhostHandler({'runtime': runtime, 'pull_runtime': pull_runtime})
-            localhost_handler.invoke(job_payload, workers=1)
+            localhost_handler.invoke(job_payload)
         except Exception as e:
             logger.error(e)
 

--- a/lithops/storage/storage.py
+++ b/lithops/storage/storage.py
@@ -24,8 +24,7 @@ from lithops.version import __version__
 from lithops.constants import CACHE_DIR, RUNTIMES_PREFIX, JOBS_PREFIX, TEMP_PREFIX
 from lithops.utils import is_lithops_worker
 from lithops.storage.utils import create_status_key, create_output_key, \
-    status_key_suffix, init_key_suffix, CloudObject, StorageNoSuchKeyError,\
-    create_job_key
+    status_key_suffix, init_key_suffix, CloudObject, StorageNoSuchKeyError
 from lithops.config import extract_storage_config, default_storage_config
 
 logger = logging.getLogger(__name__)

--- a/lithops/version.py
+++ b/lithops/version.py
@@ -1,5 +1,5 @@
 
-__version__ = "2.3.6.dev1"
+__version__ = "2.3.6.dev0"
 
 if __name__ == "__main__":
     print(__version__)

--- a/lithops/version.py
+++ b/lithops/version.py
@@ -1,5 +1,5 @@
 
-__version__ = "2.3.6.dev0"
+__version__ = "2.3.6.dev1"
 
 if __name__ == "__main__":
     print(__version__)

--- a/lithops/wait.py
+++ b/lithops/wait.py
@@ -99,37 +99,42 @@ def wait(fs, internal_storage=None, throw_except=True, timeout=None,
         pbar.update(len(fs_done))
 
     try:
-        jobs = _create_jobs_from_futures(fs, internal_storage)
+        executors_data = _create_executors_data_from_futures(fs, internal_storage)
+
         if not job_monitor:
-            job_monitor = JobMonitor(backend='storage')
-            [job_monitor.create(**job_data).start() for job_data in jobs]
+            for executor_data in executors_data:
+                job_monitor = JobMonitor(
+                    executor_id=executor_data['executor_id'],
+                    internal_storage=executor_data['internal_storage'],
+                    backend='storage')
+                job_monitor.start(fs=executor_data['futures'])
 
         sleep_sec = wait_dur_sec if job_monitor.backend == 'storage' else 0.3
 
         if return_when == ALL_COMPLETED:
             while not _all_done(fs, download_results):
-                for job_data in jobs:
-                    new_data = _get_job_data(fs, job_data, pbar=pbar,
-                                             throw_except=throw_except,
-                                             download_results=download_results,
-                                             threadpool_size=threadpool_size)
+                for executor_data in executors_data:
+                    new_data = _get_executor_data(fs, executor_data, pbar=pbar,
+                                                  throw_except=throw_except,
+                                                  download_results=download_results,
+                                                  threadpool_size=threadpool_size)
                 time.sleep(0 if new_data else sleep_sec)
 
         elif return_when == ANY_COMPLETED:
             while not _any_done(fs, download_results):
-                for job_data in jobs:
-                    new_data = _get_job_data(fs, job_data, pbar=pbar,
-                                             throw_except=throw_except,
-                                             download_results=download_results,
-                                             threadpool_size=threadpool_size)
+                for executor_data in executors_data:
+                    new_data = _get_executor_data(fs, executor_data, pbar=pbar,
+                                                  throw_except=throw_except,
+                                                  download_results=download_results,
+                                                  threadpool_size=threadpool_size)
                 time.sleep(0 if new_data else sleep_sec)
 
         elif return_when == ALWAYS:
-            for job_data in jobs:
-                _get_job_data(fs, job_data, pbar=pbar,
-                              throw_except=throw_except,
-                              download_results=download_results,
-                              threadpool_size=threadpool_size)
+            for executor_data in executors_data:
+                _get_executor_data(fs, executor_data, pbar=pbar,
+                                   throw_except=throw_except,
+                                   download_results=download_results,
+                                   threadpool_size=threadpool_size)
 
     except KeyboardInterrupt as e:
         if download_results:
@@ -197,32 +202,25 @@ def get_result(fs, throw_except=True, timeout=None,
     return result
 
 
-def _create_jobs_from_futures(fs, internal_storage):
+def _create_executors_data_from_futures(fs, internal_storage):
     """
     Creates a dummy job necessary for the job monitor
     """
-    jobs = []
-    present_jobs = {f.job_key for f in fs}
+    executor_jobs = []
+    present_executors = {f.executor_id for f in fs}
 
-    for job_key in present_jobs:
-        job_data = {}
-        job = SimpleNamespace()
-        job.futures = [f for f in fs if f.job_key == job_key]
-        job.total_calls = len(job.futures)
-        f = job.futures[0]
-        job.executor_id = f.executor_id
-        job.job_id = f.job_id
-        job.job_key = f.job_key
-        job_data['job'] = job
-
+    for executor_id in present_executors:
+        executor_data = {'executor_id': executor_id}
+        executor_data['futures'] = [f for f in fs if f.executor_id == executor_id]
+        f = executor_data['futures'][0]
         if internal_storage and internal_storage.backend == f._storage_config['backend']:
-            job_data['internal_storage'] = internal_storage
+            executor_data['internal_storage'] = internal_storage
         else:
-            job_data['internal_storage'] = InternalStorage(f._storage_config)
+            executor_data['internal_storage'] = InternalStorage(f._storage_config)
 
-        jobs.append(job_data)
+        executor_jobs.append(executor_data)
 
-    return jobs
+    return executor_jobs
 
 
 def _all_done(fs, download_results):
@@ -245,25 +243,25 @@ def _any_done(fs, download_results):
         return any([f.success or f.done for f in fs])
 
 
-def _get_job_data(fs, job_data, download_results, throw_except, threadpool_size, pbar):
+def _get_executor_data(fs, executor_data, download_results, throw_except, threadpool_size, pbar):
     """
     Downloads all status/results from ready futures
     """
-    job = job_data['job']
-    internal_storage = job_data['internal_storage']
+    futures = executor_data['futures']
+    internal_storage = executor_data['internal_storage']
 
     if download_results:
-        callids_done = [(f.executor_id, f.job_id, f.call_id) for f in job.futures if (f.ready or f.success)]
-        not_done_futures = [f for f in job.futures if not f.done]
+        callids_done = [(f.executor_id, f.job_id, f.call_id) for f in futures if (f.ready or f.success)]
+        not_done_futures = [f for f in futures if not f.done]
     else:
-        callids_done = [(f.executor_id, f.job_id, f.call_id) for f in job.futures if f.ready]
-        not_done_futures = [f for f in job.futures if not (f.success or f.done)]
+        callids_done = [(f.executor_id, f.job_id, f.call_id) for f in futures if f.ready]
+        not_done_futures = [f for f in futures if not (f.success or f.done)]
 
     not_done_call_ids = set([(f.executor_id, f.job_id, f.call_id) for f in not_done_futures])
     new_callids_done = not_done_call_ids.intersection(callids_done)
 
     fs_to_wait_on = []
-    for f in job.futures:
+    for f in futures:
         if (f.executor_id, f.job_id, f.call_id) in new_callids_done:
             fs_to_wait_on.append(f)
 
@@ -291,7 +289,7 @@ def _get_job_data(fs, job_data, download_results, throw_except, threadpool_size,
     new_futures = list(chain(*[f._new_futures for f in fs_to_wait_on if f._new_futures]))
     if new_futures:
         fs.extend(new_futures)
-        job.futures.extend(new_futures)
+        futures.extend(new_futures)
         if pbar:
             pbar.total = pbar.total + len(new_futures)
             pbar.refresh()

--- a/lithops/worker/invoker.py
+++ b/lithops/worker/invoker.py
@@ -39,19 +39,33 @@ def function_invoker(job_payload):
            '__LITHOPS_SESSION_ID': job.job_key}
     os.environ.update(env)
 
-    # Create the monitoring system
-    monitoring_backend = config['lithops']['monitoring'].lower()
-    monitoring_config = config.get(monitoring_backend)
-    job_monitor = JobMonitor(monitoring_backend, monitoring_config)
-
+    # Create the internal_storage handler
     storage_config = extract_storage_config(config)
     internal_storage = InternalStorage(storage_config)
 
+    # Create the compute handler
     serverless_config = extract_serverless_config(config)
     compute_handler = ServerlessHandler(serverless_config, storage_config)
 
-    # Create the invokder
-    invoker = FaaSRemoteInvoker(config, job.executor_id, internal_storage, compute_handler, job_monitor)
+    # Create the monitoring system
+    monitoring_backend = config['lithops']['monitoring'].lower()
+    monitoring_config = config.get(monitoring_backend)
+
+    job_monitor = JobMonitor(
+        executor_id=job.executor_id,
+        internal_storage=internal_storage,
+        backend=monitoring_backend,
+        config=monitoring_config
+    )
+
+    # Create the invoker
+    invoker = FaaSRemoteInvoker(
+        config,
+        job.executor_id,
+        internal_storage,
+        compute_handler,
+        job_monitor
+    )
     invoker.run_job(job)
 
 
@@ -64,14 +78,18 @@ class FaaSRemoteInvoker(FaaSInvoker):
         """
         Run a job
         """
-        job_monitor = self.job_monitor.create(job, self.internal_storage, generate_tokens=True)
-        self._run_job(job)
-        job_monitor.start()
+        futures = self._run_job(job)
+        self.job_monitor.start(
+            fs=futures,
+            job_id=job.job_id,
+            chunksize=job.chunksize,
+            generate_tokens=True
+        )
 
         while self.pending_calls_q.qsize() > 0:
             time.sleep(1)
 
-        job_monitor.stop()  # Stop job monitor thread
+        self.job_monitor.stop()  # Stop job monitor thread
         self.stop()  # Stop async invokers threads
         time.sleep(5)
 

--- a/lithops/worker/status.py
+++ b/lithops/worker/status.py
@@ -119,9 +119,9 @@ class RabbitmqCallStatus(StorageCallStatus):
         output_query_count = 0
 
         queues = []
-        job_keys = self.job.job_key.split('-')
-        for k in range(int(len(job_keys)/3)):
-            qname = 'lithops-{}'.format('-'.join(job_keys[0:k*3+3]))
+        executor_keys = self.job.executor_id.split('-')
+        for k in range(int(len(executor_keys)/2)):
+            qname = 'lithops-{}'.format('-'.join(executor_keys[0:k*3+2]))
             queues.append(qname)
 
         while not status_sent and output_query_count < 5:


### PR DESCRIPTION
With this patch, performance of multiple `call_async()` invoked with a `for loop` is equivalent to a single `map()` call

- There is now one monitor per `FunctionExecutor` instead of one monitor per jobs (this substantially reduces COS Requests when there are multiple jobs in the same executor)
- Created a cache for runtime meta
- Improve `lithops.cleaner` performance (this substantially reduces COS Requests when there are multiple jobs in the same executor)
 

Execution example previous this patch:

![previous](https://user-images.githubusercontent.com/10448186/126567736-2ca5422f-e234-4ae4-bfa0-9eb41f6389e2.png)

Execution example with this patch:

![new](https://user-images.githubusercontent.com/10448186/126570656-f5fb931d-693a-49a1-87a1-cefaae7e7007.png)



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

