### PR TITLE
Avoid running workflows on users forks

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -3,12 +3,13 @@ name: "Nightly Build"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 21 * * *'  # 21:00 UTC == 24:00 Israel time
+    - cron: '0 21 * * *'  # 21:00 UTC
 
 
 jobs:
 
   Determine_Runnable_Jobs:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
     outputs:
       jobs_to_run: ${{ steps.script.outputs.string }}
@@ -29,7 +30,7 @@ jobs:
 
 
   CE_COS:
-
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
 
     needs: Determine_Runnable_Jobs
@@ -64,6 +65,7 @@ jobs:
 
 
   CF_COS:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
 
     needs: Determine_Runnable_Jobs
@@ -98,6 +100,7 @@ jobs:
 
 
   LOCAL_HOST:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
 
     needs: Determine_Runnable_Jobs
@@ -123,6 +126,7 @@ jobs:
 
 
   Clean:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
     if: always()  # this job will run regardless of the above job's status.
     needs: [CE_COS,CF_COS]
@@ -148,11 +152,3 @@ jobs:
         run: |
           python3 ./lithops/scripts/config_fill_secrets.py "CF_COS" "${GITHUB_ACTOR,,}" "${{ secrets.IAMAPIKEY }}" "${{secrets.CF_COS_API}}" "${{ secrets.CF_API_KEY }}"
           lithops clean -c lithops/tests/config_files/lithops_config_CF_COS.yaml
-
-
-
-
-
-
-
-

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -9,6 +9,7 @@ on:
 jobs:
 
   Determine_Runnable_Jobs:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
     outputs:
       jobs_to_run: ${{ steps.script.outputs.string }}
@@ -28,6 +29,7 @@ jobs:
 
 
   CE_COS:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
     needs: Determine_Runnable_Jobs
     if: contains(needs.Determine_Runnable_Jobs.outputs.jobs_to_run,'CE_COS')
@@ -63,6 +65,7 @@ jobs:
 
 
   CF_COS:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
     needs: Determine_Runnable_Jobs
     if: contains(needs.Determine_Runnable_Jobs.outputs.jobs_to_run,'CF_COS')
@@ -96,6 +99,7 @@ jobs:
 
 
   LOCAL_HOST:
+    if: github.repository_owner = 'lithops-cloud'
     runs-on: ubuntu-latest
     needs: Determine_Runnable_Jobs
     if: contains(needs.Determine_Runnable_Jobs.outputs.jobs_to_run,'LOCAL_HOST')
@@ -117,8 +121,3 @@ jobs:
           LITHOPS_CONFIG_FILE: ${{ github.workspace }}/lithops/tests/config_files/lithops_config_LOCAL.yaml
         run: |
           lithops verify
-
-
-
-
-


### PR DESCRIPTION
Seems workflows also run on all users forks (master branch). Users fork do not need to run these workflows. Moreover, github workflows quota is limited per user and this can consume all the users quota.

Couldn't test it yet since it is not merged, but this should avoid running these workflows on users forks.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

