### PR TITLE
prevent loading storage config when using lithops build command

### DIFF
--- a/lithops/config.py
+++ b/lithops/config.py
@@ -93,7 +93,7 @@ def load_config(log=True):
     if not config_data:
         # Set to Localhost mode
         if log:
-            logger.debug("Config not found. Setting Lithops to localhost mode")
+            logger.debug("Config file not found")
         config_data = {'lithops': {'mode': constants.LOCALHOST,
                                    'backend': constants.LOCALHOST,
                                    'storage': constants.LOCALHOST}}
@@ -122,7 +122,7 @@ def get_log_info(config_data=None):
     return cl['log_level'], cl['log_format'], cl['log_stream'], cl['log_filename']
 
 
-def default_config(config_data=None, config_overwrite={}):
+def default_config(config_data=None, config_overwrite={}, load_storage_config=True):
     """
     First checks .lithops_config
     then checks LITHOPS_CONFIG_FILE environment variable
@@ -233,10 +233,11 @@ def default_config(config_data=None, config_overwrite={}):
     if 'monitoring' not in config_data['lithops']:
         config_data['lithops']['monitoring'] = constants.MONITORING_DEFAULT
 
-    config_data = default_storage_config(config_data)
+    if load_storage_config:
+        config_data = default_storage_config(config_data)
 
-    if config_data['lithops']['storage'] == constants.LOCALHOST and mode != constants.LOCALHOST:
-        raise Exception('Localhost storage backend cannot be used in {} mode'.format(mode))
+        if config_data['lithops']['storage'] == constants.LOCALHOST and mode != constants.LOCALHOST:
+            raise Exception('Localhost storage backend cannot be used in {} mode'.format(mode))
 
     return config_data
 

--- a/lithops/scripts/cli.py
+++ b/lithops/scripts/cli.py
@@ -385,25 +385,19 @@ def create(name, storage, backend, memory, timeout, config):
 @click.option('--backend', '-b', default=None, help='compute backend')
 def build(name, file, config, backend):
     """ build a serverless runtime. """
+
+    verify_runtime_name(name)
+
     if config:
         config = load_yaml_config(config)
 
     setup_lithops_logger(logging.DEBUG)
 
     config_ow = set_config_ow(backend)
-    config = default_config(config, config_ow)
-
-    if not name:
-        backend = config['lithops']['backend']
-        name = config[backend]['runtime']
-
-    verify_runtime_name(name)
-
-    storage_config = extract_storage_config(config)
-    internal_storage = InternalStorage(storage_config)
+    config = default_config(config, config_ow, load_storage_config=False)
 
     compute_config = extract_serverless_config(config)
-    compute_handler = ServerlessHandler(compute_config, internal_storage)
+    compute_handler = ServerlessHandler(compute_config, None)
     compute_handler.build_runtime(name, file)
 
 


### PR DESCRIPTION
As stated by @sergii-mamedov in https://github.com/metaspace2020/metaspace/pull/916, there is no need to load the storage config when running the `lithops build` command
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

