### PR TITLE
Add new command in cli to list deployed runtimes

### DIFF
--- a/lithops/scripts/cli.py
+++ b/lithops/scripts/cli.py
@@ -348,8 +348,7 @@ def runtime(ctx):
 @click.option('--debug', '-d', is_flag=True, help='debug mode')
 def create(name, storage, backend, memory, timeout, config, debug):
     """ Create a serverless runtime """
-    log_level = logging.INFO if not debug else logging.DEBUG
-    setup_lithops_logger(log_level)
+    setup_lithops_logger(logging.DEBUG)
 
     verify_runtime_name(name)
 
@@ -387,7 +386,6 @@ def create(name, storage, backend, memory, timeout, config, debug):
 @click.option('--debug', '-d', is_flag=True, help='debug mode')
 def build(name, file, config, backend, debug):
     """ build a serverless runtime. """
-    log_level = logging.INFO if not debug else logging.DEBUG
     setup_lithops_logger(logging.DEBUG)
 
     verify_runtime_name(name)
@@ -454,8 +452,7 @@ def list_runtimes(config, backend, debug):
 @click.option('--debug', '-d', is_flag=True, help='debug mode')
 def update(name, config, backend, storage, debug):
     """ Update a serverless runtime """
-    log_level = logging.INFO if not debug else logging.DEBUG
-    setup_lithops_logger(log_level)
+    setup_lithops_logger(logging.DEBUG)
 
     verify_runtime_name(name)
 
@@ -496,8 +493,7 @@ def update(name, config, backend, storage, debug):
 @click.option('--debug', '-d', is_flag=True, help='debug mode')
 def delete(name, config, backend, storage, debug):
     """ delete a serverless runtime """
-    log_level = logging.INFO if not debug else logging.DEBUG
-    setup_lithops_logger(log_level)
+    setup_lithops_logger(logging.DEBUG)
 
     verify_runtime_name(name)
 


### PR DESCRIPTION
Add command: `lithops runtime list`
This allows to list currently deployed runtimes.
Example output:

```
2021-08-26 17:14:11,006 [INFO] lithops.config -- Lithops v2.4.2.dev0
2021-08-26 17:14:11,376 [INFO] lithops.serverless.backends.code_engine.code_engine -- IBM Code Engine client created - Region: us-south

Runtime Name                    	 Memory Size (MB)
------------------------------- 	 --------------------
jsampe/metaspace-lithops-ce:1.0 	 256

Total runtimes: 1
```



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

