### PR TITLE
deleted docker naming restrictions in CE and k8s backends

### DIFF
--- a/lithops/serverless/backends/ibm_cf/ibm_cf.py
+++ b/lithops/serverless/backends/ibm_cf/ibm_cf.py
@@ -128,6 +128,7 @@ class IBMCloudFunctionsBackend:
         res = os.system(cmd)
         if res != 0:
             raise Exception('There was an error pushing the runtime to the container registry')
+        logger.info('Building done!')
 
     def create_runtime(self, docker_image_name, memory, timeout):
         """

--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -82,14 +82,11 @@ class KubernetesBackend:
         logger.info("{} - Namespace: {}".format(msg, self.namespace))
 
     def _format_job_name(self, runtime_name, runtime_memory):
-        runtime_name = runtime_name.replace('/', '--').replace(':', '--')
+        runtime_name = runtime_name.replace('/', '--')
+        runtime_name = runtime_name.replace(':', '--')
+        runtime_name = runtime_name.replace('.', '')
+        runtime_name = runtime_name.replace('_', '-')
         return '{}--{}mb'.format(runtime_name, runtime_memory)
-
-    def _unformat_job_name(self, service_name):
-        runtime_name, memory = service_name.rsplit('--', 1)
-        image_name = runtime_name.replace('--', '/', 1)
-        image_name = image_name.replace('--', ':', -1)
-        return image_name, int(memory.replace('mb', ''))
 
     def _get_default_runtime_image_name(self):
         docker_user = self.k8s_config.get('docker_user')
@@ -106,13 +103,6 @@ class KubernetesBackend:
         """
         logger.debug('Building new docker image from Dockerfile')
         logger.debug('Docker image name: {}'.format(docker_image_name))
-
-        expression = '^([a-z0-9]+)/([-a-z0-9]+)(:[a-z0-9]+)?'
-        result = re.match(expression, docker_image_name)
-
-        if not result or result.group() != docker_image_name:
-            raise Exception("Invalid docker image name: All letters must be "
-                            "lowercase and '.' or '_' characters are not allowed")
 
         entry_point = os.path.join(os.path.dirname(__file__), 'entry_point.py')
         create_handler_zip(k8s_config.FH_ZIP_LOCATION, entry_point, 'lithopsentry.py')


### PR DESCRIPTION
Delete docker naming restrictions according to #743 #738 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

