### PR TITLE
fixed numpy support python 3.9 runtime in aws

### DIFF
--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -22,7 +22,7 @@ import logging
 import atexit
 import pickle
 import tempfile
-import numpy as np
+
 import subprocess as sp
 from datetime import datetime
 from lithops import constants
@@ -544,7 +544,7 @@ class FunctionExecutor:
         :param cloud_objects_n: number of cloud object used in COS, declared by user.
         """
         import pandas as pd
-
+        import numpy as np
         def init():
             headers = ['Job_ID', 'Function', 'Invocations', 'Memory(MB)', 'AvgRuntime', 'Cost', 'CloudObjects']
             pd.DataFrame([], columns=headers).to_csv(self.log_path, index=False)

--- a/lithops/serverless/backends/aws_lambda/aws_lambda.py
+++ b/lithops/serverless/backends/aws_lambda/aws_lambda.py
@@ -432,7 +432,7 @@ class AWSLambdaBackend:
                 Description=self.package,
                 Timeout=timeout,
                 MemorySize=memory,
-                Layers=[layer_arn, self._get_numpy_layer_arn(self.region_name)],
+                Layers=[layer_arn],
                 VpcConfig={
                     'SubnetIds': self.aws_lambda_config['vpc']['subnets'],
                     'SecurityGroupIds': self.aws_lambda_config['vpc']['security_groups']

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -28,7 +28,8 @@ DEFAULT_REQUIREMENTS = [
     'pika',
     'cloudpickle',
     'ps-mem',
-    'tblib'
+    'tblib',
+    "numpy"
 ]
 
 DOCKER_PATH = shutil.which('docker')

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -25,7 +25,6 @@ import logging
 import inspect
 import requests
 import traceback
-import numpy as np
 from pydoc import locate
 from distutils.util import strtobool
 


### PR DESCRIPTION
Using a precompiled KLayers numpy layer iin aws backend breaks in python3.9 runtime as there is no numpy KLayer for python 3.9
however currently numpy is needed at the get pre installed call (otherwise fails the import)
In order to fix the above we lazily loading numpy when needed, and adding it to default requirements



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

