### PR TITLE
preparation for python39 aws support

### DIFF
--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -22,7 +22,7 @@ import logging
 import atexit
 import pickle
 import tempfile
-import numpy as np
+
 import subprocess as sp
 from datetime import datetime
 from lithops import constants
@@ -544,7 +544,7 @@ class FunctionExecutor:
         :param cloud_objects_n: number of cloud object used in COS, declared by user.
         """
         import pandas as pd
-
+        import numpy as np
         def init():
             headers = ['Job_ID', 'Function', 'Invocations', 'Memory(MB)', 'AvgRuntime', 'Cost', 'CloudObjects']
             pd.DataFrame([], columns=headers).to_csv(self.log_path, index=False)

--- a/lithops/serverless/backends/aws_lambda/aws_lambda.py
+++ b/lithops/serverless/backends/aws_lambda/aws_lambda.py
@@ -432,7 +432,7 @@ class AWSLambdaBackend:
                 Description=self.package,
                 Timeout=timeout,
                 MemorySize=memory,
-                Layers=[layer_arn, self._get_numpy_layer_arn(self.region_name)],
+                Layers=[layer_arn],
                 VpcConfig={
                     'SubnetIds': self.aws_lambda_config['vpc']['subnets'],
                     'SecurityGroupIds': self.aws_lambda_config['vpc']['security_groups']

--- a/lithops/serverless/backends/aws_lambda/aws_lambda.py
+++ b/lithops/serverless/backends/aws_lambda/aws_lambda.py
@@ -146,7 +146,7 @@ class AWSLambdaBackend:
             module_location = os.path.dirname(os.path.abspath(lithops.__file__))
             main_file = os.path.join(current_location, 'entry_point.py')
             lithops_zip.write(main_file,
-                              '__main__.py',
+                              'main.py',
                               zipfile.ZIP_DEFLATED)
             add_directory_to_zip(lithops_zip, module_location, sub_dir='lithops')
 
@@ -425,7 +425,7 @@ class AWSLambdaBackend:
                 FunctionName=function_name,
                 Runtime=lambda_config.LAMBDA_PYTHON_VER_KEY,
                 Role=self.role_arn,
-                Handler='__main__.lambda_handler',
+                Handler='main.lambda_handler',
                 Code={
                     'ZipFile': code
                 },

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -28,7 +28,8 @@ DEFAULT_REQUIREMENTS = [
     'pika',
     'cloudpickle',
     'ps-mem',
-    'tblib'
+    'tblib',
+    "numpy"
 ]
 
 DOCKER_PATH = shutil.which('docker')

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -25,7 +25,6 @@ import logging
 import inspect
 import requests
 import traceback
-import numpy as np
 from pydoc import locate
 from distutils.util import strtobool
 


### PR DESCRIPTION
1)
Using a precompiled KLayers numpy layer iin aws backend breaks in python3.9 runtime as there is no numpy KLayer for python 3.9
however currently numpy is needed at the get pre installed call (otherwise fails the import)
In order to fix the above we lazily loading numpy when needed, and adding it to default requirements


2)
in python3.9 runtime using __main__.py as entrypoint  breaks the aws bootstrap code - resulting in an "Runtime.HandlerNotFound: Handler 'lambda_handler' missing on module '__main__'"  error.
 
 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

