### PR TITLE
Adding VM reuse option for vpc standalone backend

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -196,5 +196,5 @@ fexec = lithops.FunctionExecutor(monitoring='rabbitmq')
 |standalone | auto_dismantle | True |no | If False then the VM is not stopped automatically. Run **exec.dismantle()** explicitly to stop the VM. |
 |standalone | soft_dismantle_timeout | 300 |no| Time in seconds to stop the VM instance after a job **completed** its execution |
 |standalone | hard_dismantle_timeout | 3600 | no | Time in seconds to stop the VM instance after a job **started** its execution |
-|standalone | exec_mode | consume | no | One of: **consume** or **create**. If set to  **create**, Lithops will automatically create VMs based on the number of elements in iterdata |
+|standalone | exec_mode | consume | no | One of: **consume**, **create** or **reuse**. If set to  **create**, Lithops will automatically create VMs based on the number of elements in iterdata. If set to **reuse** will try to reuse running workers if exist |
 |standalone | pull_runtime | False | no | If set to True, Lithops will execute the command `docker pull <runtime_name>` in each VSI before executing the a job|

--- a/lithops/localhost/localhost.py
+++ b/lithops/localhost/localhost.py
@@ -82,7 +82,10 @@ class LocalhostHandler:
 
         local_job_dir = os.path.join(LITHOPS_TEMP_DIR, storage_bucket, JOBS_PREFIX)
         docker_job_dir = f'/tmp/lithops/{storage_bucket}/{JOBS_PREFIX}'
-        job_file = f'{job_key}-job.json'
+
+        # resolves race condition in case multiple separate calls of a same job arrive to same worker,
+        # the file would have same name for all tasks and would be deleted by runner after first would complete
+        job_file = f'{job_key}-{job_payload["call_ids"][0]}job.json'
 
         os.makedirs(local_job_dir, exist_ok=True)
         local_job_filename = os.path.join(local_job_dir, job_file)

--- a/lithops/standalone/backends/ibm_vpc/config.py
+++ b/lithops/standalone/backends/ibm_vpc/config.py
@@ -49,7 +49,7 @@ def load_config(config_data):
         config_data['ibm_vpc'].update(config_data['ibm'])
 
     if 'exec_mode' in config_data['standalone'] \
-       and config_data['standalone']['exec_mode'] == 'create':
+       and config_data['standalone']['exec_mode'] in ['create', 'reuse']:
         params_to_check = MANDATORY_PARAMETERS_2
     else:
         params_to_check = MANDATORY_PARAMETERS_3

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -256,8 +256,8 @@ class IBMVPCBackend:
             self.master.public_ip = self.config['ip_address']
             self.master.delete_on_dismantle = False
 
-        elif self.mode == 'create':
-            logger.debug('Initializing IBM VPC backend (Create mode)')
+        elif self.mode in ['create', 'reuse']:
+            logger.debug(f'Initializing IBM VPC backend ({self.mode} mode)')
 
             if self.mode != cahced_mode:
                 # invalidate cached data

--- a/lithops/standalone/keeper.py
+++ b/lithops/standalone/keeper.py
@@ -69,10 +69,9 @@ class BudgetKeeper(threading.Thread):
         while runing:
             time_since_last_usage = time.time() - self.last_usage_time
             check_interval = self.soft_dismantle_timeout / 10
-            for job_key in self.jobs.keys():
-                done = os.path.join(JOBS_DIR, job_key+'.done')
-                if os.path.isfile(done):
-                    self.jobs[job_key] = 'done'
+
+            logger.debug(f"self.jobs: {self.jobs}")
+
             if len(self.jobs) > 0 and all(value == 'done' for value in self.jobs.values()) \
                and self.auto_dismantle:
 

--- a/lithops/standalone/keeper.py
+++ b/lithops/standalone/keeper.py
@@ -81,7 +81,8 @@ class BudgetKeeper(threading.Thread):
                 if jobs_running:
                     jobs_running = False
                     self.last_usage_time = time.time()
-                    time_since_last_usage = time.time() - self.last_usage_time
+
+                time_since_last_usage = time.time() - self.last_usage_time
 
                 time_to_dismantle = int(self.soft_dismantle_timeout - time_since_last_usage)
             else:

--- a/lithops/standalone/master.py
+++ b/lithops/standalone/master.py
@@ -51,6 +51,8 @@ MASTER_IP = None
 
 MP_MANAGER = mp.Manager()
 
+EXEC_MODE = 'consume'
+WORKERS = MP_MANAGER.list()
 
 def is_worker_instance_ready(vm):
     """
@@ -85,12 +87,13 @@ def wait_worker_instance_ready(vm):
     raise TimeoutError(msg)
 
 
-def setup_worker(worker_info, work_queue, job_key):
+def setup_worker(worker_info, work_queue, job_key, workers):
     """
     Run worker process
     Install all the Lithops dependencies into the worker.
     Runs the job
     """
+
     instance_name, ip_address, instance_id = worker_info
     logger.info('Starting setup for VM instance {}'.format(instance_name))
 
@@ -139,6 +142,8 @@ def setup_worker(worker_info, work_queue, job_key):
     vm.get_ssh_client().run_remote_command(script, run_async=True)
     vm.del_ssh_client()
     logger.info('Installation script submitted to {}'.format(vm))
+    logger.debug(f'Appending to WORKERS {vm_data}')
+    workers.append(vm_data)
 
 
 def stop_job_process(job_key):
@@ -156,7 +161,7 @@ def stop_job_process(job_key):
     del JOB_PROCESSES[job_key]
 
 
-def run_job_process(job_payload, work_queue):
+def run_job_process(job_payload, work_queue, workers_list):
     """
     Process responsible to wait for workers to become ready, and
     submit individual tasks of the job to them
@@ -175,11 +180,13 @@ def run_job_process(job_payload, work_queue):
 
     logger.info("Total tasks in {} work queue: {}".format(job_key, work_queue.qsize()))
 
-    with ThreadPoolExecutor(len(workers)) as executor:
-        for worker_info in workers:
-            executor.submit(setup_worker, worker_info, work_queue, job_key)
+    # run setup only in case not reusing old workers
+    if workers:
+        with ThreadPoolExecutor(len(workers)) as executor:
+            for worker_info in workers:
+                executor.submit(setup_worker, worker_info, work_queue, job_key, workers_list)
 
-    logger.info('All workers set up for job {}'.format(job_key))
+        logger.info('All workers set up for job {}'.format(job_key))
 
     while not work_queue.empty():
         time.sleep(1)
@@ -189,12 +196,39 @@ def run_job_process(job_payload, work_queue):
 
     logger.info('Finished job {} invocation.'.format(job_key))
 
-
 def error(msg):
     response = flask.jsonify({'error': msg})
     response.status_code = 404
     return response
 
+@app.route('/workers', methods=['GET'])
+def get_workers():
+    """
+    Returns the number of spawned workers
+
+    Currently returns only spawned workers metadata
+    TODO - add support to list only available workers when each worker updates itself in WORKERS via POST
+    TODO - job.done for master is not same as job.done for worker, can be improved by touch on master from worker instead of touch on master
+    """
+    logger.debug(f'in get_workers, workers = {WORKERS}')
+
+    workers = []
+    for w in WORKERS:
+        vm = STANDALONE_HANDLER.backend.get_vm(w['instance_name'])
+        vm.ip_address = w['ip_address']
+        vm.instance_id = w['instance_id']
+        if is_worker_instance_ready(vm):
+            workers.append(w)
+        else:
+            # delete worker in case it is not available. may cover edge cases when for some reason keeper not started on worker
+            vm.delete()
+
+    workers = [w for w in WORKERS]
+
+    response = flask.jsonify(workers)
+    response.status_code = 200
+
+    return response
 
 @app.route('/get-task/<job_key>', methods=['GET'])
 def get_task(job_key):
@@ -205,14 +239,15 @@ def get_task(job_key):
     global JOB_PROCESSES
 
     try:
-        task_payload = WORK_QUEUES[job_key].get(timeout=0.1)
+        task_payload = WORK_QUEUES.setdefault(job_key, MP_MANAGER.Queue()).get(timeout=0.1)
         response = flask.jsonify(task_payload)
         response.status_code = 200
         logger.info('Calls {} invoked on {}'
                     .format(', '.join(task_payload['call_ids']),
                             flask.request.remote_addr))
     except queue.Empty:
-        stop_job_process(job_key)
+        if EXEC_MODE != 'reuse':
+            stop_job_process(job_key)
         response = ('', 204)
     return response
 
@@ -243,6 +278,10 @@ def run():
     global WORK_QUEUES
     global JOB_PROCESSES
 
+    global WORKERS
+
+    global EXEC_MODE
+
     job_payload = flask.request.get_json(force=True, silent=True)
     if job_payload and not isinstance(job_payload, dict):
         return error('The action did not receive a dictionary as an argument.')
@@ -261,6 +300,7 @@ def run():
     BUDGET_KEEPER.jobs[job_key] = 'running'
 
     exec_mode = job_payload['config']['standalone'].get('exec_mode', 'consume')
+    EXEC_MODE = exec_mode
 
     if exec_mode == 'consume':
         # Consume mode runs the job locally
@@ -275,10 +315,21 @@ def run():
         # Create mode runs the job in worker VMs
         work_queue = MP_MANAGER.Queue()
         WORK_QUEUES[job_key] = work_queue
-        jp = mp.Process(target=run_job_process, args=(job_payload, work_queue))
+        jp = mp.Process(target=run_job_process, args=(job_payload, work_queue, WORKERS))
         jp.daemon = True
         jp.start()
         JOB_PROCESSES[job_key] = jp
+    elif exec_mode == 'reuse':
+        # Reuse mode runs the job on running workers
+        # TODO: Consider to add support to manage pull of available workers
+        # TODO: Spawn only the missing delta of workers
+        work_queue = WORK_QUEUES.setdefault('all', MP_MANAGER.Queue())
+
+        jp = mp.Process(target=run_job_process, args=(job_payload, work_queue, WORKERS))
+        jp.daemon = True
+        jp.start()
+        JOB_PROCESSES[job_key] = jp
+
 
     act_id = str(uuid.uuid4()).replace('-', '')[:12]
     response = flask.jsonify({'activationId': act_id})

--- a/lithops/standalone/master.py
+++ b/lithops/standalone/master.py
@@ -223,8 +223,6 @@ def get_workers():
             # delete worker in case it is not available. may cover edge cases when for some reason keeper not started on worker
             vm.delete()
 
-    workers = [w for w in WORKERS]
-
     response = flask.jsonify(workers)
     response.status_code = 200
 

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -159,7 +159,6 @@ class StandaloneHandler:
             try:
                 cmd = (f'curl -X GET http://127.0.0.1:{STANDALONE_SERVICE_PORT}/workers -H \'Content-Type: application/json\'')
                 workers_on_master = json.loads(self.backend.master.get_ssh_client().run_remote_command(cmd))
-                self.backend.master.del_ssh_client()
             except Exception:
                 pass
 

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -259,7 +259,9 @@ class StandaloneHandler:
             self.backend.master.del_ssh_client()
         except Exception:
             pass
-        self.backend.clear(job_keys)
+
+        if self.exec_mode != 'reuse':
+            self.backend.clear(job_keys)
 
     def get_runtime_key(self, runtime_name, *args):
         """

--- a/lithops/standalone/worker.py
+++ b/lithops/standalone/worker.py
@@ -38,11 +38,13 @@ def wait_job_completed(job_key):
     """
     Waits unitl the current job is completed
     """
+    global BUDGET_KEEPER
+
     done = os.path.join(JOBS_DIR, job_key+'.done')
     while True:
         if os.path.isfile(done):
-# deleting the file prevents keeper detect job finish
-#            os.remove(done)
+            BUDGET_KEEPER.jobs[job_key] = 'done'
+            os.remove(done)
             break
         time.sleep(1)
 
@@ -60,7 +62,6 @@ def run_worker(master_ip, job_key):
 
         if resp.status_code != 200:
             if STANDALONE_CONFIG.get('exec_mode') == 'reuse':
-                logger.debug('All tasks completed, waiting for new tasks'.format(url))
                 time.sleep(1)
                 continue
             else:


### PR DESCRIPTION
when `standalone.exec_mode == reuse`:

- If no running workers detected
  - spawn required number of workers
  - run tasks on workers
- else
  - run all tasks on existing workers
  - if less workers than tasks, same worker used for multiple tasks

- keeper keeps workers untill soft_dismantle_timeout reached



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

