### PR TITLE
Fixing bug introduced in keeper

### DIFF
--- a/lithops/standalone/keeper.py
+++ b/lithops/standalone/keeper.py
@@ -70,6 +70,11 @@ class BudgetKeeper(threading.Thread):
             time_since_last_usage = time.time() - self.last_usage_time
             check_interval = self.soft_dismantle_timeout / 10
 
+            for job_key in self.jobs.keys():
+                done = os.path.join(JOBS_DIR, job_key+'.done')
+                if os.path.isfile(done):
+                    self.jobs[job_key] = 'done'
+
             logger.debug(f"self.jobs: {self.jobs}")
 
             if len(self.jobs) > 0 and all(value == 'done' for value in self.jobs.values()) \


### PR DESCRIPTION
Fixing a bug introduced in #754 

bug: master keeper  never detects that job finished and never switches to soft_dismantle_timeout

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

