### PR TITLE
[AWS Lambda] Moved layer build to lambda -- Add support for Python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [CLI] Prevent loading storage config when using 'lithops runtime build' command
 - [AWS Lambda] Moved layer build to a lambda, solves OS related errors when compiling libraries
 - [AWS Lambda] Adjusted new memory configurations (128 MB minimum and removed 64 MB increments check)
+- [AWS Lambda] Add support for Python3.9
 
 ### Fixes
 - [CE] Prevent exception when detecting the docker username in k8s and CE backends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changed
 - [CE] Deleted docker naming restrictions in CE and k8s backends
 - [CLI] Prevent loading storage config when using 'lithops runtime build' command
+- [AWS Lambda] Moved layer build to a lambda, solves OS related errors when compiling libraries
+- [AWS Lambda] Adjusted new memory configurations (128 MB minimum and removed 64 MB increments check)
 
 ### Fixes
 - [CE] Prevent exception when detecting the docker username in k8s and CE backends

--- a/lithops/serverless/backends/aws_lambda/aws_lambda.py
+++ b/lithops/serverless/backends/aws_lambda/aws_lambda.py
@@ -15,42 +15,28 @@
 #
 
 import os
-import shutil
 import logging
 import boto3
 import time
 import json
 import zipfile
-import sys
 import subprocess
 import lithops
 import botocore.exceptions
 import base64
-import requests
 
 from botocore.httpsession import URLLib3Session
 from botocore.awsrequest import AWSRequest
 from botocore.auth import SigV4Auth
 
-from lithops.constants import TEMP as TEMP_PATH
 from lithops.constants import COMPUTE_CLI_MSG
 from . import config as lambda_config
+from lithops import utils
 
 logger = logging.getLogger(__name__)
 
-LAYER_DIR_PATH = os.path.join(TEMP_PATH, 'modules', 'python')
-LAYER_ZIP_PATH = os.path.join(TEMP_PATH, 'lithops_layer.zip')
-FUNCTION_ZIP = 'lithops_lambda.zip'
-
-
-# Auxiliary function to recursively add a directory to a zip archive
-def add_directory_to_zip(zip_file, full_dir_path, sub_dir=''):
-    for file in os.listdir(full_dir_path):
-        full_path = os.path.join(full_dir_path, file)
-        if os.path.isfile(full_path):
-            zip_file.write(full_path, os.path.join(sub_dir, file), zipfile.ZIP_DEFLATED)
-        elif os.path.isdir(full_path) and '__pycache__' not in full_path:
-            add_directory_to_zip(zip_file, full_path, os.path.join(sub_dir, file))
+LITHOPS_FUNCTION_ZIP = 'lithops_lambda.zip'
+BUILD_LAYER_FUNCTION_ZIP = 'build_layer.zip'
 
 
 class AWSLambdaBackend:
@@ -86,8 +72,8 @@ class AWSLambdaBackend:
         self.lambda_client = self.aws_session.client(
             'lambda', region_name=self.region_name,
             config=botocore.client.Config(
-                       user_agent_extra=self.user_agent
-                   )
+                user_agent_extra=self.user_agent
+            )
         )
 
         self.credentials = self.aws_session.get_credentials()
@@ -139,37 +125,17 @@ class AWSLambdaBackend:
         @param remove: True to delete the zip archive after building
         @return: Lithops handler function as zip bytes
         """
-        logger.debug('Creating function handler zip in {}'.format(FUNCTION_ZIP))
+        current_location = os.path.dirname(os.path.abspath(__file__))
+        main_file = os.path.join(current_location, 'entry_point.py')
+        utils.create_handler_zip(LITHOPS_FUNCTION_ZIP, main_file, '__main__.py')
 
-        with zipfile.ZipFile(FUNCTION_ZIP, 'w') as lithops_zip:
-            current_location = os.path.dirname(os.path.abspath(__file__))
-            module_location = os.path.dirname(os.path.abspath(lithops.__file__))
-            main_file = os.path.join(current_location, 'entry_point.py')
-            lithops_zip.write(main_file,
-                              '__main__.py',
-                              zipfile.ZIP_DEFLATED)
-            add_directory_to_zip(lithops_zip, module_location, sub_dir='lithops')
-
-        with open(FUNCTION_ZIP, 'rb') as action_zip:
+        with open(LITHOPS_FUNCTION_ZIP, 'rb') as action_zip:
             action_bin = action_zip.read()
 
         if remove:
-            os.remove(FUNCTION_ZIP)
+            os.remove(LITHOPS_FUNCTION_ZIP)
 
         return action_bin
-
-    @staticmethod
-    def _get_numpy_layer_arn(region_name):
-        """
-        Gets last pre-built numpy layer ARN using Klayers API (https://github.com/keithrozario/Klayers) based on region
-        @return: Numpy Klayer ARN
-        """
-        res = requests.get('https://api.klayers.cloud/api/v1/layers/latest/{}/numpy'.format(region_name))
-        res_json = res.json()
-        logger.debug(res_json)
-        if not res_json or 'arn' not in res_json:
-            raise Exception('Could not get numpy layer ARN from Klayers - Response: {}'.format(res_json))
-        return res_json['arn']
 
     def _get_layer(self, runtime_name):
         """
@@ -193,43 +159,59 @@ class AWSLambdaBackend:
         """
         logger.info('Creating default lambda layer for runtime {}'.format(runtime_name))
 
-        if self.internal_storage.backend != "aws_s3":
-            raise Exception('"aws_s3" is required as storage backend for publishing the lambda layer. '
-                            'You can use "aws_s3" to create the runtime and then change the storage backend afterwards.')
+        with zipfile.ZipFile(BUILD_LAYER_FUNCTION_ZIP, 'w') as build_layer_zip:
+            current_location = os.path.dirname(os.path.abspath(__file__))
+            build_layer_file = os.path.join(current_location, 'build_layer.py')
+            build_layer_zip.write(build_layer_file, 'build_layer.py', zipfile.ZIP_DEFLATED)
 
-        # Delete download and build target directory if it exists
-        if os.path.exists(LAYER_DIR_PATH):
-            if os.path.isdir(LAYER_DIR_PATH):
-                shutil.rmtree(LAYER_DIR_PATH)
-            elif os.path.isfile(LAYER_DIR_PATH):
-                os.remove(LAYER_DIR_PATH)
+        func_name = '_'.join([self.package, 'layer_builder']).replace('.', '-')
 
-        # Create target directory
-        os.makedirs(LAYER_DIR_PATH)
+        with open(BUILD_LAYER_FUNCTION_ZIP, 'rb') as build_layer_zip:
+            build_layer_zip_bin = build_layer_zip.read()
 
-        # Install and build modules to target directory
-        dependencies = [dependency.strip().replace(' ', '') for dependency in lambda_config.DEFAULT_REQUIREMENTS]
-        logger.debug('Going to download and build {} modules to {}'.format(len(dependencies), LAYER_DIR_PATH))
-        command = [sys.executable, '-m', 'pip', 'install', '-t', LAYER_DIR_PATH]
-        command.extend(dependencies)
+        logger.debug('Creating layer builder function')
 
-        if logger.getEffectiveLevel() != logging.DEBUG:
-            subprocess.check_call(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        else:
-            subprocess.check_call(command)
+        try:
+            self.lambda_client.create_function(
+                FunctionName=func_name,
+                Runtime=lambda_config.LAMBDA_PYTHON_VER_KEY,
+                Role=self.role_arn,
+                Handler='build_layer.lambda_handler',
+                Code={
+                    'ZipFile': build_layer_zip_bin
+                },
+                Timeout=120,
+                MemorySize=512
+            )
 
-        # Compress modules
-        with zipfile.ZipFile(LAYER_ZIP_PATH, 'w') as layer_zip:
-            add_directory_to_zip(layer_zip, os.path.join(TEMP_PATH, 'modules'))
+            dependencies = [dependency.strip().replace(' ', '') for dependency in lambda_config.DEFAULT_REQUIREMENTS]
+            layer_name = self._format_layer_name(runtime_name)
+            payload = {
+                'dependencies': dependencies,
+                'bucket': self.internal_storage.bucket,
+                'key': layer_name
+            }
 
-        # Read zip as bytes
-        with open(LAYER_ZIP_PATH, 'rb') as layer_zip:
-            layer_bytes = layer_zip.read()
+            logger.debug('Invoking layer builder function')
+
+            response = self.lambda_client.invoke(
+                FunctionName=func_name,
+                Payload=json.dumps(payload)
+            )
+            if response['ResponseMetadata']['HTTPStatusCode'] == 200:
+                logger.debug('OK --> Layer {} built'.format(layer_name))
+            else:
+                msg = 'An error occurred creating layer {}: {}'.format(layer_name, response)
+                raise Exception(msg)
+        finally:
+            logger.debug('Deleting layer builder function')
+            self.lambda_client.delete_function(
+                FunctionName=func_name
+            )
+            os.remove(BUILD_LAYER_FUNCTION_ZIP)
 
         # Publish layer from S3
-        layer_name = self._format_layer_name(runtime_name)
         logger.debug('Creating layer {} ...'.format(layer_name))
-        self.internal_storage.put_data(layer_name, layer_bytes)
         response = self.lambda_client.publish_layer_version(
             LayerName=layer_name,
             Description=self.package,
@@ -329,7 +311,7 @@ class AWSLambdaBackend:
             cmd = '{} build -t {} .'.format(lambda_config.DOCKER_PATH, image_name)
 
         subprocess.check_call(cmd.split())
-        os.remove(FUNCTION_ZIP)
+        os.remove(LITHOPS_FUNCTION_ZIP)
 
         registry = '{}.dkr.ecr.{}.amazonaws.com'.format(self.account_id, self.region_name)
 
@@ -432,7 +414,7 @@ class AWSLambdaBackend:
                 Description=self.package,
                 Timeout=timeout,
                 MemorySize=memory,
-                Layers=[layer_arn, self._get_numpy_layer_arn(self.region_name)],
+                Layers=[layer_arn],
                 VpcConfig={
                     'SubnetIds': self.aws_lambda_config['vpc']['subnets'],
                     'SecurityGroupIds': self.aws_lambda_config['vpc']['security_groups']

--- a/lithops/serverless/backends/aws_lambda/aws_lambda.py
+++ b/lithops/serverless/backends/aws_lambda/aws_lambda.py
@@ -127,7 +127,7 @@ class AWSLambdaBackend:
         """
         current_location = os.path.dirname(os.path.abspath(__file__))
         main_file = os.path.join(current_location, 'entry_point.py')
-        utils.create_handler_zip(LITHOPS_FUNCTION_ZIP, main_file, '__main__.py')
+        utils.create_handler_zip(LITHOPS_FUNCTION_ZIP, main_file, 'entry_point.py')
 
         with open(LITHOPS_FUNCTION_ZIP, 'rb') as action_zip:
             action_bin = action_zip.read()
@@ -407,7 +407,7 @@ class AWSLambdaBackend:
                 FunctionName=function_name,
                 Runtime=lambda_config.LAMBDA_PYTHON_VER_KEY,
                 Role=self.role_arn,
-                Handler='__main__.lambda_handler',
+                Handler='entry_point.lambda_handler',
                 Code={
                     'ZipFile': code
                 },

--- a/lithops/serverless/backends/aws_lambda/aws_lambda.py
+++ b/lithops/serverless/backends/aws_lambda/aws_lambda.py
@@ -221,7 +221,11 @@ class AWSLambdaBackend:
             },
             CompatibleRuntimes=[lambda_config.LAMBDA_PYTHON_VER_KEY]
         )
-        self.internal_storage.storage.delete_object(self.internal_storage.bucket, layer_name)
+
+        try:
+            self.internal_storage.storage.delete_object(self.internal_storage.bucket, layer_name)
+        except Exception as e:
+            logger.warning(e)
 
         if response['ResponseMetadata']['HTTPStatusCode'] == 201:
             logger.debug('OK --> Layer {} created'.format(layer_name))

--- a/lithops/serverless/backends/aws_lambda/build_layer.py
+++ b/lithops/serverless/backends/aws_lambda/build_layer.py
@@ -1,0 +1,47 @@
+import json
+import subprocess
+import os
+import zipfile
+import boto3
+import sys
+import shutil
+
+
+TEMP_PATH = '/tmp'
+LAYER_DIR_PATH = os.path.join(TEMP_PATH, 'modules', 'python')
+LAYER_ZIP_PATH = '/tmp/layer.zip'
+
+
+def add_directory_to_zip(zip_file, full_dir_path, sub_dir=''):
+    for file in os.listdir(full_dir_path):
+        full_path = os.path.join(full_dir_path, file)
+        if os.path.isfile(full_path):
+            zip_file.write(full_path, os.path.join(sub_dir, file), zipfile.ZIP_DEFLATED)
+        elif os.path.isdir(full_path) and '__pycache__' not in full_path:
+            add_directory_to_zip(zip_file, full_path, os.path.join(sub_dir, file))
+
+
+def lambda_handler(event, context):
+    if os.path.exists(LAYER_DIR_PATH):
+        if os.path.isdir(LAYER_DIR_PATH):
+            shutil.rmtree(LAYER_DIR_PATH)
+        elif os.path.isfile(LAYER_DIR_PATH):
+            os.remove(LAYER_DIR_PATH)
+
+    os.makedirs(LAYER_DIR_PATH)
+
+    command = [sys.executable, '-m', 'pip', 'install', '-t', LAYER_DIR_PATH]
+    command.extend(event['dependencies'])
+    subprocess.check_call(command)
+
+    with zipfile.ZipFile(LAYER_ZIP_PATH, 'w') as layer_zip:
+        add_directory_to_zip(layer_zip, os.path.join(TEMP_PATH, 'modules'))
+
+    client = boto3.client('s3')
+    with open(LAYER_ZIP_PATH, 'rb') as layer_zip:
+        client.put_object(Body=layer_zip, Bucket=event['bucket'], Key=event['key'])
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps(event)
+    }

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -42,6 +42,7 @@ USER_RUNTIME_PREFIX = 'lithops.user_runtimes'
 RUNTIME_TIMEOUT_DEFAULT = 180  # Default timeout: 180 s == 3 min
 RUNTIME_TIMEOUT_MAX = 900  # Max. timeout: 900 s == 15 min
 RUNTIME_MEMORY_DEFAULT = 256  # Default memory: 256 MB
+RUNTIME_MEMORY_MIN = 128  # Max. memory: 128 MB
 RUNTIME_MEMORY_MAX = 10240  # Max. memory: 10240 MB
 
 MAX_CONCURRENT_WORKERS = 1000
@@ -58,14 +59,14 @@ def load_config(config_data):
         config_data['aws_lambda']['invoke_pool_threads'] = INVOKE_POOL_THREADS_DEFAULT
     if 'runtime_memory' not in config_data['aws_lambda']:
         config_data['aws_lambda']['runtime_memory'] = RUNTIME_MEMORY_DEFAULT
-    if config_data['aws_lambda']['runtime_memory'] % 64 != 0:     # Adjust 64 MB memory increments restriction
-        mem = config_data['aws_lambda']['runtime_memory']
-        config_data['aws_lambda']['runtime_memory'] = (mem + (64 - (mem % 64)))
     if config_data['aws_lambda']['runtime_memory'] > RUNTIME_MEMORY_MAX:
         logger.warning("Memory set to {} - {} exceeds "
                        "the maximum amount".format(RUNTIME_MEMORY_MAX, config_data['aws_lambda']['runtime_memory']))
         config_data['aws_lambda']['runtime_memory'] = RUNTIME_MEMORY_MAX
-
+    if config_data['aws_lambda']['runtime_memory'] < RUNTIME_MEMORY_MIN:
+        logger.warning("Memory set to {} - {} is lower than "
+                       "the minimum amount".format(RUNTIME_MEMORY_MIN, config_data['aws_lambda']['runtime_memory']))
+        config_data['aws_lambda']['runtime_memory'] = RUNTIME_MEMORY_MIN
     if 'runtime_timeout' not in config_data['aws_lambda']:
         config_data['aws_lambda']['runtime_timeout'] = RUNTIME_TIMEOUT_DEFAULT
     if config_data['aws_lambda']['runtime_timeout'] > RUNTIME_TIMEOUT_DEFAULT:

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -36,7 +36,7 @@ DOCKER_PATH = shutil.which('docker')
 
 LAMBDA_PYTHON_VER_KEY = 'python{}'.format(version_str(sys.version_info))
 DEFAULT_RUNTIME = LAMBDA_PYTHON_VER_KEY.replace('.', '')
-AVAILABLE_RUNTIMES = ['python36', 'python37', 'python38']
+AVAILABLE_RUNTIMES = ['python36', 'python37', 'python38', 'python39']
 
 USER_RUNTIME_PREFIX = 'lithops.user_runtimes'
 

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -23,6 +23,7 @@ from lithops.utils import version_str
 logger = logging.getLogger(__name__)
 
 DEFAULT_REQUIREMENTS = [
+    'numpy',
     'requests',
     'redis',
     'pika',


### PR DESCRIPTION
- Moved layer build to a lambda, solves OS related errors when compiling libraries and numpy is added to the dependencies (no need to use third party layers) (#745)
- Adjusted new memory configurations (128 MB minimum and removed 64 MB increments check)
- Add support for Python3.9 (#746)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

