### PR TITLE
update outdated list of ce_regions with a programmatically up-to-date…

### DIFF
--- a/lithops/serverless/backends/code_engine/config.py
+++ b/lithops/serverless/backends/code_engine/config.py
@@ -18,6 +18,8 @@ import os
 import sys
 import shutil
 
+import requests
+
 from lithops.utils import version_str, get_docker_username
 from lithops.version import __version__
 
@@ -192,6 +194,7 @@ def load_config(config_data):
                         '{}'.format(runtime_memory, VALID_MEMORY_VALUES))
 
     region = config_data['code_engine'].get('region')
+    get_ce_regions()
     if region and region not in VALID_REGIONS:
         raise Exception('{} is an invalid region name. Set one of: '
                         '{}'.format(region, VALID_REGIONS))
@@ -199,3 +202,18 @@ def load_config(config_data):
     if 'workers' not in config_data['lithops'] or \
        config_data['lithops']['workers'] > MAX_CONCURRENT_WORKERS:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
+
+
+def get_ce_regions():
+    """initializes a list of the available regions in which a user can create a code engine project"""
+    global VALID_REGIONS
+
+    try:
+        response = requests.get(
+            'https://globalcatalog.cloud.ibm.com/api/v1/814fb158-af9c-4d3c-a06b-c7da42392845/%2A').json()
+    except:
+        VALID_REGIONS = ['us-south', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok']
+        return
+
+    for resource in response['resources']:
+        VALID_REGIONS.append(resource['geo_tags'][0])

--- a/lithops/serverless/backends/code_engine/config.py
+++ b/lithops/serverless/backends/code_engine/config.py
@@ -39,7 +39,7 @@ FH_ZIP_LOCATION = os.path.join(os.getcwd(), 'lithops_codeengine.zip')
 
 VALID_CPU_VALUES = [0.125, 0.25, 0.5, 1, 2, 4, 6, 8]
 VALID_MEMORY_VALUES = [256, 512, 1024, 2048, 4096, 8192, 12288, 16384, 24576, 32768]
-VALID_REGIONS = ['us-south', 'jp-tok', 'eu-de', 'eu-gb']
+VALID_REGIONS = ['us-south', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok']
 
 CLUSTER_URL = 'https://proxy.{}.codeengine.cloud.ibm.com'
 
@@ -194,7 +194,6 @@ def load_config(config_data):
                         '{}'.format(runtime_memory, VALID_MEMORY_VALUES))
 
     region = config_data['code_engine'].get('region')
-    get_ce_regions()
     if region and region not in VALID_REGIONS:
         raise Exception('{} is an invalid region name. Set one of: '
                         '{}'.format(region, VALID_REGIONS))
@@ -203,17 +202,3 @@ def load_config(config_data):
        config_data['lithops']['workers'] > MAX_CONCURRENT_WORKERS:
         config_data['lithops']['workers'] = MAX_CONCURRENT_WORKERS
 
-
-def get_ce_regions():
-    """initializes a list of the available regions in which a user can create a code engine project"""
-    global VALID_REGIONS
-
-    try:
-        response = requests.get(
-            'https://globalcatalog.cloud.ibm.com/api/v1/814fb158-af9c-4d3c-a06b-c7da42392845/%2A').json()
-    except:
-        VALID_REGIONS = ['us-south', 'ca-tor', 'eu-de', 'eu-gb', 'jp-osa', 'jp-tok']
-        return
-
-    for resource in response['resources']:
-        VALID_REGIONS.append(resource['geo_tags'][0])


### PR DESCRIPTION
The current list of regions in which one can create a new ce project in, is outdate. using the get request i offer will make sure the list will stay up-to-date. 
I've originally created this function for the lithops-cloud/lithopscloud project. 


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

