### PR TITLE
Make reduce function spawning in map_reduce() more flexible

### DIFF
--- a/docs/api_futures.md
+++ b/docs/api_futures.md
@@ -192,7 +192,7 @@ Spawn multiple *map_function* activations,  based on the items of an input list,
 |worker_processes | 1 | Number of concurrent/parallel processes in each worker|
 |extra_args|  None | Additional arguments to pass to each map_function activation |
 |reduce_function|  |The function to map over the results of map_function |
-|reducer_wait_local| False |Wait locally for map results |
+|spawn_reducer| ANY_COMPLETED | When to spawn the reducer function. One of: ALWAYS, ANY_COMPLETED, ALL_COMPLETED |
 |extra_env| None | Additional environment variables for CF environment|
 |map_runtime_memory| 256 | Memory (in MB) to use to run the map_function|
 |reduce_runtime_memory| 256| Memory (in MB) to use to run the reduce_function|
@@ -215,7 +215,6 @@ Spawn multiple *map_function* activations,  based on the items of an input list,
 
 * **Code example**: [map_reduce.py](../examples/map_reduce.py)
 
-By default, the *reduce_function* is immediately spawned, and then it waits remotely to get all the results from the map phase. It should be note that, although faster, this approach consumes CPU time in Cloud Functions. You can change this behavior and make *reduce_function* to wait locally for the results by setting the `reducer_wait_local` parameter to `True`. However, it has the tradeoff of greater data transfers, because it has to download all the results to the local machine and then upload them again to the cloud for processing with the *reduce_function*.
 
 ## Executor.wait()
 

--- a/examples/map_reduce.py
+++ b/examples/map_reduce.py
@@ -7,6 +7,7 @@ wait locally for the results. Once the results be ready, it
 will launch the reduce function.
 """
 import lithops
+from lithops.wait import ALWAYS
 
 iterdata = [1, 2, 3, 4]
 
@@ -32,9 +33,9 @@ if __name__ == "__main__":
     print(fexec.get_result())
 
     """
-    Set 'reducer_wait_local=True' to wait for the results locally.
+    Set 'spawn_reducer=ALWAYS' to immediately spawn the reducers.
     """
     fexec = lithops.FunctionExecutor()
     fexec.map_reduce(my_map_function, iterdata, my_reduce_function,
-                     reducer_wait_local=True)
+                     spawn_reducer=ALWAYS)
     print(fexec.get_result())

--- a/lithops/wait.py
+++ b/lithops/wait.py
@@ -26,10 +26,9 @@ from lithops.monitor import JobMonitor
 from types import SimpleNamespace
 from itertools import chain
 
-
-ALL_COMPLETED = 1
-ANY_COMPLETED = 2
-ALWAYS = 3
+ALWAYS = 0
+ANY_COMPLETED = 1
+ALL_COMPLETED = 100
 
 THREADPOOL_SIZE = 64
 WAIT_DUR_SEC = 1


### PR DESCRIPTION
This patch makes the reduce function spawning in map_reduce() more flexible: Now it is possible to spawn the reducer immediately (**ALWAYS**), when one of the map functions finishes its execution (**ANY_COMPLETED**), or when all the map functions finished their executions (**ALL_COMPLETED**).

In the future, this will allow to specify a percentage of number of completed map functions before spawning the reduce function. For example: when 80% of the map functions are completed, spawn the reducer.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

