### PR TITLE
fix wrong keyword arg in get_result() method

### DIFF
--- a/examples/serialize_futures.py
+++ b/examples/serialize_futures.py
@@ -1,0 +1,35 @@
+"""
+This example show how a lithops function can be invoked
+in one machine and get the results in another machine by
+simply serializing and passing the futures.
+"""
+import time
+import os
+
+# ---------------------- Machine 1 ---------------------
+import lithops
+import pickle
+
+
+def my_map_function(id, x):
+    print("I'm activation number {}".format(id))
+    return x + 7
+
+
+fexec = lithops.FunctionExecutor()
+futures = fexec.map(my_map_function, range(5))
+with open('futures.pickle', 'wb') as file:
+    pickle.dump(futures, file)
+
+time.sleep(5)
+
+
+# ---------------------- Machine 2---------------------
+import pickle
+from lithops.wait import get_result
+
+with open('futures.pickle', 'rb') as file:
+    futures = pickle.load(file)
+results = get_result(futures)
+print(results)
+os.remove('futures.pickle')

--- a/lithops/wait.py
+++ b/lithops/wait.py
@@ -159,7 +159,7 @@ def wait(fs, internal_storage=None, throw_except=True, timeout=None,
 
 
 def get_result(fs, throw_except=True, timeout=None,
-               threadpool_zise=THREADPOOL_SIZE,
+               threadpool_size=THREADPOOL_SIZE,
                wait_dur_sec=WAIT_DUR_SEC,
                internal_storage=None):
     """
@@ -179,7 +179,7 @@ def get_result(fs, throw_except=True, timeout=None,
     fs_done, _ = wait(fs=fs, throw_except=throw_except,
                       timeout=timeout, download_results=True,
                       internal_storage=internal_storage,
-                      threadpool_zise=threadpool_zise,
+                      threadpool_size=threadpool_size,
                       wait_dur_sec=wait_dur_sec)
     result = []
     fs_done = [f for f in fs_done if not f.futures and f._produce_output]


### PR DESCRIPTION
Add `serialize futures` examples to show how a function can be invoked in one machine, and results can be get from another machine
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

