### PR TITLE
enable set boot_volume_capacity from config

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/config.py
+++ b/lithops/standalone/backends/ibm_vpc/config.py
@@ -83,11 +83,12 @@ def load_config(config_data):
 
     config_data['ibm_vpc']['endpoint'] = config_data['ibm_vpc']['endpoint'].replace('/v1', '')
 
-    if config_data['ibm_vpc']['image_id'] == DEFAULT_CONFIG_KEYS['image_id']:
-        config_data['ibm_vpc']['boot_volume_capacity'] = BOOT_VOLUME_CAPACITY_DEFAULT
-    else:
-        # The image built by lithops script has 10GB boot device
-        config_data['ibm_vpc']['boot_volume_capacity'] = BOOT_VOLUME_CAPACITY_CUSTOM
+    if not config_data['ibm_vpc'].get('boot_volume_capacity'):
+        if config_data['ibm_vpc']['image_id'] == DEFAULT_CONFIG_KEYS['image_id']:
+            config_data['ibm_vpc']['boot_volume_capacity'] = BOOT_VOLUME_CAPACITY_DEFAULT
+        else:
+            # The image built by lithops script has 10GB boot device
+            config_data['ibm_vpc']['boot_volume_capacity'] = BOOT_VOLUME_CAPACITY_CUSTOM
 
     if 'ssh_password' not in config_data['ibm_vpc']:
         config_data['ibm_vpc']['ssh_password'] = str(uuid.uuid4())


### PR DESCRIPTION
Currently, boot volume capacity is hardcoded to 100 for a specific Ubuntu image id. In case any other image chosen it is hardcoded to 10 which is wrong.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

