### PR TITLE
Multiple bug fixes

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/config.py
+++ b/lithops/standalone/backends/ibm_vpc/config.py
@@ -57,6 +57,9 @@ bootcmd:
     - sed -i '/PasswordAuthentication no/c\PasswordAuthentication yes' /etc/ssh/sshd_config
     - echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
 runcmd:
+    - echo '{0}:{1}' | chpasswd
+    - sed -i '/PasswordAuthentication no/c\PasswordAuthentication yes' /etc/ssh/sshd_config
+    - echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
     - systemctl restart sshd
 """
 

--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -625,7 +625,7 @@ class IBMVPCInstance:
         """
         ip_address = None
         if self.instance_id:
-            while not ip_address:
+            while not ip_address or ip_address == '0.0.0.0':
                 instance_data = self.ibm_vpc_client.get_instance(self.instance_id).get_result()
                 ip_address = instance_data['primary_network_interface']['primary_ipv4_address']
         return ip_address

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -161,7 +161,7 @@ class StandaloneHandler:
             current_workers_old = set(self.backend.workers)
             with ThreadPoolExecutor(total_workers+1) as ex:
                 ex.submit(start_master_instance, wait=False)
-                for vm_n in range(total_workers):
+                for vm_n in range(total_workers + 1):
                     worker_id = "{:04d}".format(vm_n)
                     name = 'lithops-worker-{}-{}-{}'.format(executor_id, job_id, worker_id)
                     ex.submit(self.backend.create_worker, name)
@@ -185,6 +185,7 @@ class StandaloneHandler:
 
         elif self.exec_mode == 'reuse':
             workers = get_workers_on_master()
+            logger.info(f"Found {len(workers)} workers connected to master {self.backend.master}")
             if workers:
                 total_workers = len(workers)
             if not workers:


### PR DESCRIPTION
- gen2 vpc changed return value of instance ip and while instance
in provisioning state its IP value may be returned as '0.0.0.0'

- lithops provisioned n-1 worker instances

- occasionally cloud-init either failed to set default credentials
in workers or credentials were overwritten due to very early phase of
bootcmd invocation. returned runcmd section to cloud config



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

