### PR TITLE
Don't start vsi instance after provisioned

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -650,14 +650,13 @@ class IBMVPCInstance:
             instance = self._create_instance()
             self.instance_id = instance['id']
             self.ip_address = self._get_ip_address()
-
-        if self.public and instance:
-            self._attach_floating_ip(instance)
-
-        if start:
+        elif start:
             # In IBM VPC, VM instances are automatically started on create
             if vsi_exists:
                 self.start()
+
+        if self.public and instance:
+            self._attach_floating_ip(instance)
 
         return self.instance_id
 


### PR DESCRIPTION
VSI instances auto-started when created. Currently, after VM provisioned, it is also triggered to start which can result in exception in some cases.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

