### PR TITLE
Validate master service setup

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -523,7 +523,7 @@ class IBMVPCInstance:
 
         return ibm_vpc_client
 
-    def get_ssh_client(self):
+    def get_ssh_client(self, unbinded=False):
         """
         Creates an ssh client against the VM only if the Instance is the master
         """
@@ -533,6 +533,12 @@ class IBMVPCInstance:
                 instance_data = self.get_instance_data()
                 self.ip_address = instance_data['primary_network_interface']['primary_ipv4_address']
                 self.instance_id = instance_data['id']
+
+            # create new instance of ssh client and return it
+            # should be closed by the caller
+            if unbinded:
+                return SSHClient(self.public_ip or self.ip_address, self.ssh_credentials)
+
             if not self.ssh_client:
                 self.ssh_client = SSHClient(self.public_ip or self.ip_address, self.ssh_credentials)
         return self.ssh_client

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -113,26 +113,36 @@ class StandaloneHandler:
     def _validate_master_service_setup(self):
         logger.info(f'Validating lithops version installed on master matches {lithops_version}')
         cmd = f'cat {STANDALONE_INSTALL_DIR}/access.data'
-        res = self.backend.master.get_ssh_client().run_remote_command(cmd)
+
+        ssh_client = self.backend.master.get_ssh_client(unbinded=True)
+        res = ssh_client.run_remote_command(cmd)
         if not res:
             raise Exception(
-                f"Lithops service not installed on {self.backend.master}, consider using 'lithops clean' to delete runtime metadata or 'lithops clean --all' to delete master instance as well")
+                f"Lithops service not installed on {self.backend.master}, consider using 'lithops clean' "
+                 "to delete runtime metadata or 'lithops clean --all' to delete master instance as well")
 
         master_lithops_version = json.loads(res).get('lithops_version')
         if master_lithops_version != lithops_version:
             raise Exception(
-                f"Lithops version {master_lithops_version} on {self.backend.master}, doesn't match local lithops version {lithops_version}, consider running 'lithops clean' to delete runtime metadata leftovers or 'lithops clean --all' to delete master instance as well")
+                f"Lithops version {master_lithops_version} on {self.backend.master}, doesn't match local "
+                f"lithops version {lithops_version}, consider running 'lithops clean' to delete runtime "
+                "metadata leftovers or 'lithops clean --all' to delete master instance as well")
 
-        logger.info(f'Validating lithops lithops master service is running on {self.backend.master}')
+        logger.info(
+            f'Validating lithops lithops master service is running on {self.backend.master}')
         cmd = "service lithops-master status"
-        res = self.backend.master.get_ssh_client().run_remote_command(cmd)
+        res = ssh_client.run_remote_command(cmd)
         if not res:
             raise Exception(
-                f"Lithops master service not installed on {self.backend.master}, consider to delete master instance and metadata using 'lithops clean --all'")
+                f"Lithops master service not installed on {self.backend.master}, consider to delete master "
+                "instance and metadata using 'lithops clean --all'")
 
         if 'Active: active (running)' not in res:
             raise Exception(
-                f"Lithops master service not active on {self.backend.master}, consider to delete master instance and metadata using 'lithops clean --all'", res)
+                f"Lithops master service not active on {self.backend.master}, consider to delete master "
+                "instance and metadata using 'lithops clean --all'", res)
+        ssh_client.close()
+        ssh_client = None
 
     def _wait_master_service_ready(self):
         """
@@ -172,6 +182,7 @@ class StandaloneHandler:
             if not self._is_master_service_ready():
                 self.backend.master.create(check_if_exists=True)
                 if wait:
+                    self._wait_master_instance_ready()
                     self._wait_master_service_ready()
 
         def get_workers_on_master():
@@ -356,3 +367,4 @@ class StandaloneHandler:
         script = get_master_setup_script(self.config, vm_data)
         ssh_client.upload_data_to_file(script, remote_script)
         ssh_client.run_remote_command(f"chmod 777 {remote_script}; sudo {remote_script};")
+

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -24,9 +24,10 @@ import shlex
 from concurrent.futures import ThreadPoolExecutor
 
 from lithops.utils import is_lithops_worker, create_handler_zip
-from lithops.constants import STANDALONE_SERVICE_PORT
+from lithops.constants import STANDALONE_SERVICE_PORT, STANDALONE_INSTALL_DIR
 from lithops.standalone.utils import get_master_setup_script
 
+from lithops.version import __version__ as lithops_version
 
 logger = logging.getLogger(__name__)
 LOCAL_FH_ZIP_LOCATION = os.path.join(os.getcwd(), 'lithops_standalone.zip')
@@ -109,10 +110,42 @@ class StandaloneHandler:
         except Exception:
             return False
 
+    def _validate_master_service_setup(self):
+        logger.info(f'Validating lithops version installed on master matches {lithops_version}')
+        cmd = f'cat {STANDALONE_INSTALL_DIR}/access.data'
+        res = self.backend.master.get_ssh_client().run_remote_command(cmd)
+        if not res:
+            raise Exception(
+                f'Lithops service not installed on {self.backend.master}, consider using \'lithops clean\' to \
+                delete runtime metadata or \'lithops clean --all\' to delete master instance as well')
+
+        master_lithops_version = json.loads(res).get('lithops_version')
+        if master_lithops_version != lithops_version:
+            raise Exception(
+                f'Lithops version {master_lithops_version} on {self.backend.master}, doesn\'t match local lithops \
+                version {lithops_version}, consider running \'lithops clean\' to \
+                delete runtime metadata leftovers or \'lithops clean --all\' to delete master instance as well')
+
+        logger.info(f'Validating lithops lithops master service is running on {self.backend.master}')
+        cmd = "service lithops-master status"
+        res = self.backend.master.get_ssh_client().run_remote_command(cmd)
+        if not res:
+            raise Exception(
+                f'Lithops master service not installed on {self.backend.master}, consider to delete master instance \
+                    and metadata using \'lithops clean --all\'')
+
+        if 'Active: active (running)' not in res:
+            raise Exception(
+                f'Lithops master service not active on {self.backend.master}, consider to delete master instance \
+                    and metadata using \'lithops clean --all\'', res)
+
     def _wait_master_service_ready(self):
         """
         Waits until the proxy is ready to receive http connections
         """
+
+        self._validate_master_service_setup()
+
         logger.info('Waiting Lithops service to become ready on {}'
                     .format(self.backend.master))
 

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -116,34 +116,28 @@ class StandaloneHandler:
         res = self.backend.master.get_ssh_client().run_remote_command(cmd)
         if not res:
             raise Exception(
-                f'Lithops service not installed on {self.backend.master}, consider using \'lithops clean\' to \
-                delete runtime metadata or \'lithops clean --all\' to delete master instance as well')
+                f"Lithops service not installed on {self.backend.master}, consider using 'lithops clean' to delete runtime metadata or 'lithops clean --all' to delete master instance as well")
 
         master_lithops_version = json.loads(res).get('lithops_version')
         if master_lithops_version != lithops_version:
             raise Exception(
-                f'Lithops version {master_lithops_version} on {self.backend.master}, doesn\'t match local lithops \
-                version {lithops_version}, consider running \'lithops clean\' to \
-                delete runtime metadata leftovers or \'lithops clean --all\' to delete master instance as well')
+                f"Lithops version {master_lithops_version} on {self.backend.master}, doesn't match local lithops version {lithops_version}, consider running 'lithops clean' to delete runtime metadata leftovers or 'lithops clean --all' to delete master instance as well")
 
         logger.info(f'Validating lithops lithops master service is running on {self.backend.master}')
         cmd = "service lithops-master status"
         res = self.backend.master.get_ssh_client().run_remote_command(cmd)
         if not res:
             raise Exception(
-                f'Lithops master service not installed on {self.backend.master}, consider to delete master instance \
-                    and metadata using \'lithops clean --all\'')
+                f"Lithops master service not installed on {self.backend.master}, consider to delete master instance and metadata using 'lithops clean --all'")
 
         if 'Active: active (running)' not in res:
             raise Exception(
-                f'Lithops master service not active on {self.backend.master}, consider to delete master instance \
-                    and metadata using \'lithops clean --all\'', res)
+                f"Lithops master service not active on {self.backend.master}, consider to delete master instance and metadata using 'lithops clean --all'", res)
 
     def _wait_master_service_ready(self):
         """
         Waits until the proxy is ready to receive http connections
         """
-
         self._validate_master_service_setup()
 
         logger.info('Waiting Lithops service to become ready on {}'
@@ -351,7 +345,9 @@ class StandaloneHandler:
 
         vm_data = {'instance_name': self.backend.master.name,
                    'ip_address': self.backend.master.ip_address,
-                   'instance_id': self.backend.master.instance_id}
+                   'instance_id': self.backend.master.instance_id,
+                   'lithops_version': lithops_version
+                   }
 
         logger.debug('Executing lithops installation process on {}'.format(self.backend.master))
         logger.debug('Be patient, initial installation process may take up to 3 minutes')


### PR DESCRIPTION
There several cases when runtime metadata and master instance may mismatch.

* Master instance manually deleted while metadata remains
* Master instance didn't finish service setup
* Master instance installed with outdated lithops version

and probably few more. 
Currently, in such cases the map function will hang until timeout waiting for master service to become available eventually crashing on timeout.

To improve user experience, in this PR we check lithops version installed on master and status of lithops-master service prior wait for service become available.

Implemented in standalone.py both for ibm_vpc and ec2. If it is not an issue for ec2 can be moved to ibm_vpc.












Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

