### PR TITLE
Validate master VM public ssh key is a pair of used private ssh key

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -18,6 +18,7 @@ import functools
 import inspect
 import re
 import os
+import subprocess
 import time
 import logging
 import uuid
@@ -507,6 +508,8 @@ class IBMVPCInstance:
             'key_filename': self.config.get('ssh_key_filename', None)
         }
 
+        self.validated = False
+
     def __str__(self):
         return f'VM instance {self.name} ({self.public_ip} {self.ip_address})' if self.public_ip else f'VM instance {self.name} {self.ip_address}'
 
@@ -535,6 +538,21 @@ class IBMVPCInstance:
                 self.instance_id = instance_data['id']
             if not self.ssh_client:
                 self.ssh_client = SSHClient(self.public_ip or self.ip_address, self.ssh_credentials)
+
+        import pdb;pdb.set_trace()
+        if not self.validated and self.public:
+            # validate that private ssh key in ssh_credentials is a pair of public key on instance
+            if not os.path.exists(os.path.abspath(os.path.expanduser(self.ssh_credentials['key_filename']))):
+                raise Exception(f"Specified private key file {self.ssh_credentials['key_filename']} doesn't exist")
+
+            initialization_data = self.ibm_vpc_client.get_instance_initialization(self.instance_id).get_result()
+            key_id = initialization_data['keys'][0]['id']
+            public_res = self.ibm_vpc_client.get_key(key_id).get_result()['public_key'].split(' ')[1]
+            private_res = subprocess.getoutput([f"ssh-keygen -y -f {self.ssh_credentials['key_filename']} | cut -d' ' -f 2"])
+
+            if not public_res == private_res:
+                raise Exception(f"Private ssh key {self.ssh_credentials['key_filename']} and public key {public_res} on master {self} are not a pair")
+
         return self.ssh_client
 
     def del_ssh_client(self):

--- a/lithops/standalone/master.py
+++ b/lithops/standalone/master.py
@@ -249,6 +249,10 @@ def get_workers():
     Returns the number of free workers
     """
     global workers
+    global BUDGET_KEEPER
+
+    # update last_usage_time to prevent race condition when keeper stops the vm
+    BUDGET_KEEPER.last_usage_time = time.time()
 
     logger.info(f'Getting workers: {workers}')
 

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -64,6 +64,7 @@ class StandaloneHandler:
         Checks if the VM instance is ready to receive ssh connections
         """
         try:
+#            import pdb;pdb.set_trace()
             self.backend.master.get_ssh_client().run_remote_command('id')
         except Exception:
             return False
@@ -142,6 +143,7 @@ class StandaloneHandler:
                                   if self.exec_mode in ['create', 'reuse'] else 1)
 
         def start_master_instance(wait=True):
+            breakpoint()
             if not self._is_master_service_ready():
                 self.backend.master.create(check_if_exists=True)
                 if wait:
@@ -162,10 +164,10 @@ class StandaloneHandler:
             current_workers_old = set(self.backend.workers)
             with ThreadPoolExecutor(workers_to_create+1) as ex:
                 ex.submit(start_master_instance, wait=False)
-                for vm_n in range(workers_to_create):
-                    worker_id = "{:04d}".format(vm_n)
-                    name = 'lithops-worker-{}-{}-{}'.format(executor_id, job_id, worker_id)
-                    ex.submit(self.backend.create_worker, name)
+#                for vm_n in range(workers_to_create):
+#                    worker_id = "{:04d}".format(vm_n)
+#                    name = 'lithops-worker-{}-{}-{}'.format(executor_id, job_id, worker_id)
+#                    ex.submit(self.backend.create_worker, name)
             current_workers_new = set(self.backend.workers)
             new_workers = current_workers_new - current_workers_old
             logger.debug("Total worker VM instances created: {}/{}"


### PR DESCRIPTION
Currently, when user has master VM already running and uses same VPC with different config.yaml having different ssh key than the one initially used with master initialization, lithops will print some weird messages, like

`oops, unhandled type 3 (‘unimplemented’)`

and will hang for very log time before failing.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

