### PR TITLE
Fix plot function when passing a FuturesList instance

### DIFF
--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -488,7 +488,7 @@ class FunctionExecutor:
         return result
 
     def plot(self,
-             fs: Optional[Union[ResponseFuture, List[ResponseFuture]]] = None,
+             fs: Optional[Union[ResponseFuture, List[ResponseFuture], FuturesList]] = None,
              dst: Optional[str] = None):
         """
         Creates timeline and histogram of the current execution in dst_dir.
@@ -498,7 +498,7 @@ class FunctionExecutor:
         """
         ftrs = self.futures if not fs else fs
 
-        if type(ftrs) != list:
+        if isinstance(ftrs, ResponseFuture):
             ftrs = [ftrs]
 
         ftrs_to_plot = [f for f in ftrs if (f.success or f.done) and not f.error]


### PR DESCRIPTION
This patch solves error when trying to plot when passing an instance of FuturesList returned by map to FunctionExecutor.plot.

Steps to reproduce:
```python
import lithops

def echo(msg):
    return msg

fexec = lithops.FunctionExecutor()

fs = fexec.map(echo, ['hello', 'hello', 'hello'])  # type of fs is FuturesList
fexec.get_result()
fexec.plot(fs=fs)
```

```
Traceback (most recent call last):
  File "/home/aitor/Projects/lithops-github/lithops/examples/plottest.py", line 17, in <module>
    fexec.plot(fs=fs2, dst='plots/'+fs2[0].executor_id+'_'+fs2[0].job_id)
  File "/home/aitor/Projects/lithops-github/lithops/lithops/executors.py", line 504, in plot
    ftrs_to_plot = [f for f in ftrs if (f.success or f.done) and not f.error]
  File "/home/aitor/Projects/lithops-github/lithops/lithops/executors.py", line 504, in <listcomp>
    ftrs_to_plot = [f for f in ftrs if (f.success or f.done) and not f.error]
AttributeError: 'FuturesList' object has no attribute 'success'

```

With this patch, all possible parameters for `fs` work as expected:
```python
import lithops


def echo(msg):
    return msg


fexec = lithops.FunctionExecutor()

fs1 = fexec.call_async(echo, 'hello')  # type of fs1 is ResponseFuture
fs2 = fexec.map(echo, ['hello', 'hello', 'hello'])  # type of fs2 is FuturesList
fs3 = fexec.map(echo, ['hello', 'hello', 'hello'])
fs3 = [fs for fs in fs3]  # type of fs3 is list of ResponseFuture
fexec.get_result()

fexec.plot(fs=fs1)
fexec.plot(fs=fs2)
fexec.plot(fs=fs3)
```

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

