### PR TITLE
validating ssh pair programmatically

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -18,6 +18,7 @@ import functools
 import inspect
 import re
 import os
+import paramiko
 import time
 import logging
 import uuid
@@ -566,7 +567,7 @@ class IBMVPCInstance:
             key_id = initialization_data['keys'][0]['id']
             key_name = initialization_data['keys'][0]['name']
             public_res = self.ibm_vpc_client.get_key(key_id).get_result()['public_key'].split(' ')[1]
-            private_res = subprocess.getoutput([f"ssh-keygen -y -f {key_filename} | cut -d' ' -f 2"])
+            private_res = paramiko.RSAKey(filename=key_filename).get_base64()
 
             if not public_res == private_res:
                 raise LithopsValidationError(


### PR DESCRIPTION
Instead of using `ssh-keygen` binary from shell now using paramiko python module to validate ssh key pair

resolves #859 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

