### PR TITLE
[Standalone] convert ssh key to abspath and raise an exception if not exists

### DIFF
--- a/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
+++ b/lithops/standalone/backends/ibm_vpc/ibm_vpc.py
@@ -563,6 +563,11 @@ class IBMVPCInstance:
         if not self.validated and self.public and self.instance_id:
             # validate that private ssh key in ssh_credentials is a pair of public key on instance
             key_filename = self.ssh_credentials['key_filename']
+            key_filename = os.path.abspath(os.path.expanduser(key_filename))
+
+            if not os.path.exists(key_filename):
+                raise LithopsValidationError(f"Private key file {key_filename} doesn't exist")
+
             initialization_data = self.ibm_vpc_client.get_instance_initialization(self.instance_id).get_result()
             key_id = initialization_data['keys'][0]['id']
             key_name = initialization_data['keys'][0]['name']


### PR DESCRIPTION
- Convert ssh key filename to abspath to prevent `[Errno 2] No such file or directory: '~/.ssh/id_rsa'`
- Raise an exception if the ssh key does not exist
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

