### PR TITLE
Add download_file() and upload_file() methods to Storage API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [v2.5.9.dev0]
 
 ### Added
-- 
+- [Storage] Added `download_file()` and `upload_file()` methods to Storage API to enable multipart upload/download
 
 ### Fixed
 - 

--- a/lithops/storage/backends/aws_s3/aws_s3.py
+++ b/lithops/storage/backends/aws_s3/aws_s3.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import os
 import logging
 import boto3
 import botocore
@@ -104,6 +105,46 @@ class S3Backend:
                 raise StorageNoSuchKeyError(bucket_name, key)
             else:
                 raise e
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file to an S3 bucket
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: S3 object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            self.s3_client.upload_file(file_name, bucket, key, ExtraArgs=extra_args)
+        except botocore.exceptions.ClientError as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file from an S3 bucket
+
+        :param bucket: Bucket to download from
+        :param key: S3 object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            self.s3_client.download_file(bucket, key, file_name, ExtraArgs=extra_args)
+        except botocore.exceptions.ClientError as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, bucket_name, key):
         '''

--- a/lithops/storage/backends/azure_storage/azure_storage.py
+++ b/lithops/storage/backends/azure_storage/azure_storage.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+import os
+import shutil
 import logging
 from io import BytesIO
 from azure.storage.blob import BlobServiceClient
@@ -83,6 +85,52 @@ class AzureBlobStorageBackend:
 
         except ResourceNotFoundError:
             raise StorageNoSuchKeyError(bucket_name, key)
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            with open(file_name, 'rb') as in_file:
+                self.put_object(bucket, key, in_file)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file
+
+        :param bucket: Bucket to download from
+        :param key: object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            dirname = os.path.dirname(file_name)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            with open(file_name, 'wb') as out:
+                data_stream = self.get_object(bucket, key, stream=True)
+                shutil.copyfileobj(data_stream, out)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, bucket_name, key):
         """

--- a/lithops/storage/backends/ceph/ceph.py
+++ b/lithops/storage/backends/ceph/ceph.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
+import os
 import logging
-import ibm_boto3
-import ibm_botocore
+import boto3
+import botocore
 from lithops.storage.utils import StorageNoSuchKeyError
 from lithops.utils import sizeof_fmt
 from lithops.constants import STORAGE_CLI_MSG
@@ -40,7 +41,7 @@ class CephStorageBackend:
 
         logger.debug("Setting Ceph endpoint to {}".format(service_endpoint))
 
-        client_config = ibm_botocore.client.Config(
+        client_config = botocore.client.Config(
             max_pool_connections=128,
             user_agent_extra=user_agent,
             connect_timeout=CONN_READ_TIMEOUT,
@@ -48,7 +49,7 @@ class CephStorageBackend:
             retries={'max_attempts': OBJ_REQ_RETRIES}
         )
 
-        self.cos_client = ibm_boto3.client(
+        self.s3_client = boto3.client(
             's3', aws_access_key_id=ceph_config['access_key_id'],
             aws_secret_access_key=ceph_config['secret_access_key'],
             config=client_config,
@@ -63,7 +64,7 @@ class CephStorageBackend:
         Get ibm_boto3 client.
         :return: ibm_boto3 client
         """
-        return self.cos_client
+        return self.s3_client
 
     def put_object(self, bucket_name, key, data):
         """
@@ -77,18 +78,18 @@ class CephStorageBackend:
         status = None
         while status is None:
             try:
-                res = self.cos_client.put_object(Bucket=bucket_name, Key=key, Body=data)
+                res = self.s3_client.put_object(Bucket=bucket_name, Key=key, Body=data)
                 status = 'OK' if res['ResponseMetadata']['HTTPStatusCode'] == 200 else 'Error'
                 try:
                     logger.debug('PUT Object {} - Size: {} - {}'.format(key, sizeof_fmt(len(data)), status))
                 except Exception:
                     logger.debug('PUT Object {} {}'.format(key, status))
-            except ibm_botocore.exceptions.ClientError as e:
+            except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] == "NoSuchKey":
                     raise StorageNoSuchKeyError(bucket_name, key)
                 else:
                     raise e
-            except ibm_botocore.exceptions.ReadTimeoutError as e:
+            except botocore.exceptions.ReadTimeoutError as e:
                 if retries == OBJ_REQ_RETRIES:
                     raise e
                 logger.debug('PUT Object timeout. Retrying request')
@@ -106,22 +107,62 @@ class CephStorageBackend:
         retries = 0
         while data is None:
             try:
-                r = self.cos_client.get_object(Bucket=bucket_name, Key=key, **extra_get_args)
+                r = self.s3_client.get_object(Bucket=bucket_name, Key=key, **extra_get_args)
                 if stream:
                     data = r['Body']
                 else:
                     data = r['Body'].read()
-            except ibm_botocore.exceptions.ClientError as e:
+            except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] == "NoSuchKey":
                     raise StorageNoSuchKeyError(bucket_name, key)
                 else:
                     raise e
-            except ibm_botocore.exceptions.ReadTimeoutError as e:
+            except botocore.exceptions.ReadTimeoutError as e:
                 if retries == OBJ_REQ_RETRIES:
                     raise e
                 logger.debug('GET Object timeout. Retrying request')
                 retries += 1
         return data
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file to an S3 bucket
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: S3 object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            self.s3_client.upload_file(file_name, bucket, key, ExtraArgs=extra_args)
+        except botocore.exceptions.ClientError as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file from an S3 bucket
+
+        :param bucket: Bucket to download from
+        :param key: S3 object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            self.s3_client.download_file(bucket, key, file_name, ExtraArgs=extra_args)
+        except botocore.exceptions.ClientError as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, bucket_name, key):
         """
@@ -134,13 +175,13 @@ class CephStorageBackend:
         retries = 0
         while metadata is None:
             try:
-                metadata = self.cos_client.head_object(Bucket=bucket_name, Key=key)
-            except ibm_botocore.exceptions.ClientError as e:
+                metadata = self.s3_client.head_object(Bucket=bucket_name, Key=key)
+            except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] == '404':
                     raise StorageNoSuchKeyError(bucket_name, key)
                 else:
                     raise e
-            except ibm_botocore.exceptions.ReadTimeoutError as e:
+            except botocore.exceptions.ReadTimeoutError as e:
                 if retries == OBJ_REQ_RETRIES:
                     raise e
                 logger.debug('HEAD Object timeout. Retrying request')
@@ -153,7 +194,7 @@ class CephStorageBackend:
         :param bucket: bucket name
         :param key: data key
         """
-        return self.cos_client.delete_object(Bucket=bucket_name, Key=key)
+        return self.s3_client.delete_object(Bucket=bucket_name, Key=key)
 
     def delete_objects(self, bucket_name, key_list):
         """
@@ -166,7 +207,7 @@ class CephStorageBackend:
         for i in range(0, len(key_list), max_keys_num):
             delete_keys = {'Objects': []}
             delete_keys['Objects'] = [{'Key': k} for k in key_list[i:i+max_keys_num]]
-            result.append(self.cos_client.delete_objects(Bucket=bucket_name, Delete=delete_keys))
+            result.append(self.s3_client.delete_objects(Bucket=bucket_name, Delete=delete_keys))
         return result
 
     def head_bucket(self, bucket_name):
@@ -177,8 +218,8 @@ class CephStorageBackend:
         :rtype: str/bytes
         """
         try:
-            return self.cos_client.head_bucket(Bucket=bucket_name)
-        except ibm_botocore.exceptions.ClientError as e:
+            return self.s3_client.head_bucket(Bucket=bucket_name)
+        except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 raise StorageNoSuchKeyError(bucket_name, '')
             else:
@@ -194,7 +235,7 @@ class CephStorageBackend:
         """
         try:
             prefix = '' if prefix is None else prefix
-            paginator = self.cos_client.get_paginator('list_objects_v2')
+            paginator = self.s3_client.get_paginator('list_objects_v2')
             page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
 
             object_list = []
@@ -203,7 +244,7 @@ class CephStorageBackend:
                     for item in page['Contents']:
                         object_list.append(item)
             return object_list
-        except ibm_botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 raise StorageNoSuchKeyError(bucket_name, '' if prefix is None else prefix)
             else:
@@ -219,7 +260,7 @@ class CephStorageBackend:
         """
         try:
             prefix = '' if prefix is None else prefix
-            paginator = self.cos_client.get_paginator('list_objects_v2')
+            paginator = self.s3_client.get_paginator('list_objects_v2')
             page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
 
             key_list = []
@@ -228,7 +269,7 @@ class CephStorageBackend:
                     for item in page['Contents']:
                         key_list.append(item['Key'])
             return key_list
-        except ibm_botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 raise StorageNoSuchKeyError(bucket_name, prefix)
             else:

--- a/lithops/storage/backends/gcp_storage/gcp_storage.py
+++ b/lithops/storage/backends/gcp_storage/gcp_storage.py
@@ -15,6 +15,8 @@
 #
 
 import re
+import os
+import shutil
 import time
 import logging
 from requests.exceptions import SSLError as TooManyConnectionsError
@@ -85,6 +87,52 @@ class GCPStorageBackend:
             return stream
         else:
             return blob.download_as_string(start=start, end=end)
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            with open(file_name, 'rb') as in_file:
+                self.put_object(bucket, key, in_file)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file
+
+        :param bucket: Bucket to download from
+        :param key: object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            dirname = os.path.dirname(file_name)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            with open(file_name, 'wb') as out:
+                data_stream = self.get_object(bucket, key, stream=True)
+                shutil.copyfileobj(data_stream, out)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, bucket_name, key):
         try:

--- a/lithops/storage/backends/gcsfs/gcsfs.py
+++ b/lithops/storage/backends/gcsfs/gcsfs.py
@@ -1,4 +1,6 @@
 import gcsfs
+import os
+import shutil
 import logging
 from lithops.storage.utils import StorageNoSuchKeyError
 from lithops.constants import STORAGE_CLI_MSG
@@ -59,6 +61,52 @@ class GcsfsStorageBackend:
                     return f.read()
         except Exception as e:
             raise StorageNoSuchKeyError(bucket_name, key)
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: S3 object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            with open(file_name, 'rb') as in_file:
+                self.put_object(bucket, key, in_file)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file
+
+        :param bucket: Bucket to download from
+        :param key: S3 object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            dirname = os.path.dirname(file_name)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            with open(file_name, 'wb') as out:
+                data_stream = self.get_object(bucket, key, stream=True)
+                shutil.copyfileobj(data_stream, out)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, bucket_name, key):
         """

--- a/lithops/storage/backends/localhost/localhost.py
+++ b/lithops/storage/backends/localhost/localhost.py
@@ -109,6 +109,52 @@ class LocalhostStorageBackend:
         except Exception:
             raise StorageNoSuchKeyError(os.path.join(LITHOPS_TEMP_DIR, bucket_name), key)
 
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: S3 object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            with open(file_name, 'rb') as in_file:
+                self.put_object(bucket, key, in_file)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file
+
+        :param bucket: Bucket to download from
+        :param key: S3 object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            dirname = os.path.dirname(file_name)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            with open(file_name, 'wb') as out:
+                data_stream = self.get_object(bucket, key, stream=True)
+                shutil.copyfileobj(data_stream, out)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
+
     def head_object(self, bucket_name, key):
         """
         Head object from local filesystem with a key.

--- a/lithops/storage/backends/minio/minio.py
+++ b/lithops/storage/backends/minio/minio.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
+import os
 import logging
-import ibm_boto3
-import ibm_botocore
+import boto3
+import botocore
 from lithops.storage.utils import StorageNoSuchKeyError
 from lithops.utils import sizeof_fmt
 from lithops.constants import STORAGE_CLI_MSG
@@ -40,7 +41,7 @@ class MinioStorageBackend:
 
         logger.debug("Setting MinIO endpoint to {}".format(service_endpoint))
 
-        client_config = ibm_botocore.client.Config(
+        client_config = botocore.client.Config(
             max_pool_connections=128,
             user_agent_extra=user_agent,
             connect_timeout=CONN_READ_TIMEOUT,
@@ -48,7 +49,7 @@ class MinioStorageBackend:
             retries={'max_attempts': OBJ_REQ_RETRIES}
         )
 
-        self.cos_client = ibm_boto3.client(
+        self.s3_client = boto3.client(
             's3', aws_access_key_id=minio_config['access_key_id'],
             aws_secret_access_key=minio_config['secret_access_key'],
             config=client_config,
@@ -63,7 +64,7 @@ class MinioStorageBackend:
         Get ibm_boto3 client.
         :return: ibm_boto3 client
         """
-        return self.cos_client
+        return self.s3_client
 
     def put_object(self, bucket_name, key, data):
         """
@@ -77,18 +78,18 @@ class MinioStorageBackend:
         status = None
         while status is None:
             try:
-                res = self.cos_client.put_object(Bucket=bucket_name, Key=key, Body=data)
+                res = self.s3_client.put_object(Bucket=bucket_name, Key=key, Body=data)
                 status = 'OK' if res['ResponseMetadata']['HTTPStatusCode'] == 200 else 'Error'
                 try:
                     logger.debug('PUT Object {} - Size: {} - {}'.format(key, sizeof_fmt(len(data)), status))
                 except Exception:
                     logger.debug('PUT Object {} {}'.format(key, status))
-            except ibm_botocore.exceptions.ClientError as e:
+            except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] == "NoSuchKey":
                     raise StorageNoSuchKeyError(bucket_name, key)
                 else:
                     raise e
-            except ibm_botocore.exceptions.ReadTimeoutError as e:
+            except botocore.exceptions.ReadTimeoutError as e:
                 if retries == OBJ_REQ_RETRIES:
                     raise e
                 logger.debug('PUT Object timeout. Retrying request')
@@ -106,22 +107,62 @@ class MinioStorageBackend:
         retries = 0
         while data is None:
             try:
-                r = self.cos_client.get_object(Bucket=bucket_name, Key=key, **extra_get_args)
+                r = self.s3_client.get_object(Bucket=bucket_name, Key=key, **extra_get_args)
                 if stream:
                     data = r['Body']
                 else:
                     data = r['Body'].read()
-            except ibm_botocore.exceptions.ClientError as e:
+            except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] == "NoSuchKey":
                     raise StorageNoSuchKeyError(bucket_name, key)
                 else:
                     raise e
-            except ibm_botocore.exceptions.ReadTimeoutError as e:
+            except botocore.exceptions.ReadTimeoutError as e:
                 if retries == OBJ_REQ_RETRIES:
                     raise e
                 logger.debug('GET Object timeout. Retrying request')
                 retries += 1
         return data
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file to an S3 bucket
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: S3 object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            self.s3_client.upload_file(file_name, bucket, key, ExtraArgs=extra_args)
+        except botocore.exceptions.ClientError as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file from an S3 bucket
+
+        :param bucket: Bucket to download from
+        :param key: S3 object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            self.s3_client.download_file(bucket, key, file_name, ExtraArgs=extra_args)
+        except botocore.exceptions.ClientError as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, bucket_name, key):
         """
@@ -134,13 +175,13 @@ class MinioStorageBackend:
         retries = 0
         while metadata is None:
             try:
-                metadata = self.cos_client.head_object(Bucket=bucket_name, Key=key)
-            except ibm_botocore.exceptions.ClientError as e:
+                metadata = self.s3_client.head_object(Bucket=bucket_name, Key=key)
+            except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] == '404':
                     raise StorageNoSuchKeyError(bucket_name, key)
                 else:
                     raise e
-            except ibm_botocore.exceptions.ReadTimeoutError as e:
+            except botocore.exceptions.ReadTimeoutError as e:
                 if retries == OBJ_REQ_RETRIES:
                     raise e
                 logger.debug('HEAD Object timeout. Retrying request')
@@ -153,7 +194,7 @@ class MinioStorageBackend:
         :param bucket: bucket name
         :param key: data key
         """
-        return self.cos_client.delete_object(Bucket=bucket_name, Key=key)
+        return self.s3_client.delete_object(Bucket=bucket_name, Key=key)
 
     def delete_objects(self, bucket_name, key_list):
         """
@@ -166,7 +207,7 @@ class MinioStorageBackend:
         for i in range(0, len(key_list), max_keys_num):
             delete_keys = {'Objects': []}
             delete_keys['Objects'] = [{'Key': k} for k in key_list[i:i+max_keys_num]]
-            result.append(self.cos_client.delete_objects(Bucket=bucket_name, Delete=delete_keys))
+            result.append(self.s3_client.delete_objects(Bucket=bucket_name, Delete=delete_keys))
         return result
 
     def head_bucket(self, bucket_name):
@@ -177,8 +218,8 @@ class MinioStorageBackend:
         :rtype: str/bytes
         """
         try:
-            return self.cos_client.head_bucket(Bucket=bucket_name)
-        except ibm_botocore.exceptions.ClientError as e:
+            return self.s3_client.head_bucket(Bucket=bucket_name)
+        except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 raise StorageNoSuchKeyError(bucket_name, '')
             else:
@@ -194,7 +235,7 @@ class MinioStorageBackend:
         """
         try:
             prefix = '' if prefix is None else prefix
-            paginator = self.cos_client.get_paginator('list_objects_v2')
+            paginator = self.s3_client.get_paginator('list_objects_v2')
             page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
 
             object_list = []
@@ -203,7 +244,7 @@ class MinioStorageBackend:
                     for item in page['Contents']:
                         object_list.append(item)
             return object_list
-        except ibm_botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 raise StorageNoSuchKeyError(bucket_name, '' if prefix is None else prefix)
             else:
@@ -219,7 +260,7 @@ class MinioStorageBackend:
         """
         try:
             prefix = '' if prefix is None else prefix
-            paginator = self.cos_client.get_paginator('list_objects_v2')
+            paginator = self.s3_client.get_paginator('list_objects_v2')
             page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
 
             key_list = []
@@ -228,7 +269,7 @@ class MinioStorageBackend:
                     for item in page['Contents']:
                         key_list.append(item['Key'])
             return key_list
-        except ibm_botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 raise StorageNoSuchKeyError(bucket_name, prefix)
             else:

--- a/lithops/storage/backends/redis/redis.py
+++ b/lithops/storage/backends/redis/redis.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
-
+import os
 import io
 import redis
+import shutil
 import logging
 from lithops.storage.utils import StorageNoSuchKeyError
 from lithops.constants import STORAGE_CLI_MSG
@@ -101,6 +102,52 @@ class RedisBackend:
             return io.BytesIO(data)
         else:
             return data
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: S3 object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            with open(file_name, 'rb') as in_file:
+                self.put_object(bucket, key, in_file)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file
+
+        :param bucket: Bucket to download from
+        :param key: S3 object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            dirname = os.path.dirname(file_name)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            with open(file_name, 'wb') as out:
+                data_stream = self.get_object(bucket, key, stream=True)
+                shutil.copyfileobj(data_stream, out)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, bucket_name, key):
         """

--- a/lithops/storage/backends/swift/swift.py
+++ b/lithops/storage/backends/swift/swift.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
+import os
 import json
+import shutil
 import logging
 import requests
 from lithops.storage.utils import StorageNoSuchKeyError
@@ -135,6 +137,52 @@ class StorageBackend:
         except Exception as e:
             print(e)
             raise StorageNoSuchKeyError(container_name, key)
+
+    def upload_file(self, file_name, bucket, key=None, extra_args={}):
+        """Upload a file
+
+        :param file_name: File to upload
+        :param bucket: Bucket to upload to
+        :param key: S3 object name. If not specified then file_name is used
+        :return: True if file was uploaded, else False
+        """
+        # If S3 key was not specified, use file_name
+        if key is None:
+            key = os.path.basename(file_name)
+
+        # Upload the file
+        try:
+            with open(file_name, 'rb') as in_file:
+                self.put_object(bucket, key, in_file)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
+
+    def download_file(self, bucket, key, file_name=None, extra_args={}):
+        """Download a file
+
+        :param bucket: Bucket to download from
+        :param key: S3 object name. If not specified then file_name is used
+        :param file_name: File to upload
+        :return: True if file was downloaded, else False
+        """
+        # If file_name was not specified, use S3 key
+        if file_name is None:
+            file_name = key
+
+        # Download the file
+        try:
+            dirname = os.path.dirname(file_name)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            with open(file_name, 'wb') as out:
+                data_stream = self.get_object(bucket, key, stream=True)
+                shutil.copyfileobj(data_stream, out)
+        except Exception as e:
+            logging.error(e)
+            return False
+        return True
 
     def head_object(self, container_name, key):
         """

--- a/lithops/storage/storage.py
+++ b/lithops/storage/storage.py
@@ -110,6 +110,32 @@ class Storage:
         """
         return self.storage_handler.get_object(bucket, key, stream, extra_get_args)
 
+    def upload_file(self, file_name: str, bucket: str, key: Optional[str] = None,
+                    extra_args: Optional[Dict] = {}) -> Union[str, bytes, TextIO, BinaryIO]:
+        """
+        Upload a file to a bucket of the storage backend. (Multipart upload)
+
+        :param bucket: Name of the bucket
+        :param key: Key of the object
+        :param body: Object data
+        :param extra_args: Extra get arguments to be passed to the underlying backend implementation (dict).
+        """
+        return self.storage_handler.upload_file(file_name, bucket, key, extra_args)
+
+    def download_file(self, bucket: str, key: str, file_name: Optional[str] = None,
+                      extra_args: Optional[Dict] = {}) -> Union[str, bytes, TextIO, BinaryIO]:
+        """
+        Download a file from the storage backend. (Multipart download)
+
+        :param bucket: Name of the bucket
+        :param key: Key of the object
+        :param stream: Get the object data or a file-like object
+        :param extra_args: Extra get arguments to be passed to the underlying backend implementation (dict).
+
+        :return: Object, as a binary array or as a file-like stream if parameter `stream` is enabled
+        """
+        return self.storage_handler.download_file(bucket, key, file_name, extra_args)
+
     def head_object(self, bucket: str, key: str) -> Dict:
         """
         The HEAD operation retrieves metadata from an object without returning the object itself. This operation is

--- a/lithops/util/ssh_client.py
+++ b/lithops/util/ssh_client.py
@@ -81,8 +81,9 @@ class SSHClient():
         if self.ssh_client is None:
             self.ssh_client = self.create_client()
 
-        if not os.path.exists(os.path.dirname(local_dst)):
-            os.makedirs(os.path.dirname(local_dst))
+        dirname = os.path.dirname(local_dst)
+        if dirname and not os.path.exists(dirname):
+            os.makedirs(dirname)
 
         ftp_client = self.ssh_client.open_sftp()
         ftp_client.get(remote_src, local_dst)


### PR DESCRIPTION
This enables much faster uploads and downloads of files to/from the storage backend when using the `lithops storage put ...` or `lithops storage get ..`. commands
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

