### PR TITLE
Changed docs for Google cloud backend refering to id instead of name

### DIFF
--- a/docs/source/compute_config/gcp_cloudrun.md
+++ b/docs/source/compute_config/gcp_cloudrun.md
@@ -36,7 +36,7 @@ $ python3 -m install lithops[gcp]
         backend: gcp_cloudrun
 
     gcp:
-        project_name : <PROJECT_NAME>
+        project_name : <PROJECT_ID>
         service_account : <SERVICE_ACCOUNT_EMAIL>
         credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
         region : <REGION_NAME>
@@ -48,7 +48,7 @@ $ python3 -m install lithops[gcp]
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
-|gcp | project_name | |yes | Project name introduced in step 3 (e.g. `lithops`) |
+|gcp | project_name | |yes | Project id given by Google Cloud Platform in step 3 (e.g. lithops-876385) |
 |gcp | service_account | |yes | Service account email of the service account created on step 5 (e.g. `lithops-executor@lithops.iam.gserviceaccount.com`) |
 |gcp | credentials_path | |yes | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`) |
 |gcp | region | |yes | Region of the bucket created at step 8. Functions and pub/sub queue will be created in the same region (e.g. `us-east1`) |

--- a/docs/source/compute_config/gcp_functions.md
+++ b/docs/source/compute_config/gcp_functions.md
@@ -37,7 +37,7 @@ $ python3 -m install lithops[gcp]
         backend: gcp_functions
 
     gcp:
-        project_name : <PROJECT_NAME>
+        project_name : <PROJECT_ID>
         service_account : <SERVICE_ACCOUNT_EMAIL>
         credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
         region : <REGION_NAME>
@@ -49,7 +49,7 @@ $ python3 -m install lithops[gcp]
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
-|gcp | project_name | |yes | Project name introduced in step 3 (e.g. `lithops`) |
+|gcp | project_name | |yes | Project id given by Google Cloud Platform in step 3 (e.g. `lithops-876385`) |
 |gcp | service_account | |yes | Service account email of the service account created on step 5 (e.g. `lithops-executor@lithops.iam.gserviceaccount.com`) |
 |gcp | credentials_path | |yes | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`) |
 |gcp | region | |yes | Region of the bucket created at step 8. Functions and pub/sub queue will be created in the same region (e.g. `us-east1`) |

--- a/docs/source/storage_config/gcp_storage.md
+++ b/docs/source/storage_config/gcp_storage.md
@@ -37,7 +37,7 @@ $ python3 -m pip install lithops[gcp]
         storage: gcp_storage
 
     gcp:
-        project_name : <PROJECT_NAME>
+        project_name : <<PROJECT_ID>>
         service_account : <SERVICE_ACCOUNT_EMAIL>
         credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
         region : <REGION_NAME>
@@ -52,7 +52,7 @@ $ python3 -m pip install lithops[gcp]
 
 |Group|Key|Default|Mandatory|Additional info|
 |---|---|---|---|---|
-|gcp | project_name | |yes | Project name introduced in step 3 (e.g. `lithops`) |
+|gcp | project_name | |yes | Project id given by Google Cloud Platform in step 3 (e.g. lithops-876385) |
 |gcp | service_account | |yes | Service account email of the service account created on step 5 (e.g. `lithops-executor@lithops.iam.gserviceaccount.com`) |
 |gcp | credentials_path | |yes | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`) |
 |gcp | region | |yes | Region of the bucket created at step 8. Functions and pub/sub queue will be created in the same region (e.g. `us-east1`) |


### PR DESCRIPTION
In the documents for Google Cloud Run and Google Cloud Functions it is stated that the lithops config file requires the name of the Google Cloud project given by the user. However, this is not true and will result in an error 404 when trying to run code with this config. Instead it is required to enter the ID given to the project by Google Cloud. I changed the affected doc-files to refer to this project id instead of the project name.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

