### PR TITLE
Fixed wrong variable name runtime_cpus for gcp_cloudrun

### DIFF
--- a/lithops/serverless/backends/gcp_cloudrun/cloudrun.py
+++ b/lithops/serverless/backends/gcp_cloudrun/cloudrun.py
@@ -270,7 +270,7 @@ class GCPCloudRunBackend:
                                 "resources": {
                                     "limits": {
                                         "memory": "{}Mi".format(memory),
-                                        "cpu": str(self.runtime_cpus)
+                                        "cpu": str(self.runtime_cpu)
                                     },
                                 },
                             }

--- a/lithops/serverless/backends/gcp_cloudrun/config.py
+++ b/lithops/serverless/backends/gcp_cloudrun/config.py
@@ -126,6 +126,6 @@ def load_config(config_data):
                                                           AVAILABLE_RUNTIME_CPUS))
     if config_data['gcp_cloudrun']['runtime_cpu'] == 4 and config_data['gcp_cloudrun']['runtime_memory'] < 4096:
         raise Exception('For {} vCPUs, runtime memory must be at least 4096 MiB'
-                        .format(config_data['gcp_cloudrun']['runtime_cpus']))
+                        .format(config_data['gcp_cloudrun']['runtime_cpu']))
 
     config_data['gcp_cloudrun'].update(config_data['gcp'])


### PR DESCRIPTION
The variable runtime_cpu was in some places referred to as runtime_cpus, which caused errors. This pull request fixes them by changing occurrences of runtime_cpus to runtime_cpu.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

