### PR TITLE
Load runtime data only on invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Added
 
 ### Changed
+- [Core] Load runtime data only on invocation
+- [Multiprocessing] Imporved remote logging
 
 ### Fixed
-
+- [knative] AttributeError: 'KnativeServingBackend' object has no attribute 'coreV1Api'
 
 ## [v2.6.0]
 

--- a/docs/source/compute_config/knative.md
+++ b/docs/source/compute_config/knative.md
@@ -23,12 +23,16 @@ Note that Lithops automatically builds the default runtime the first time you ru
 
 6. [Follow this instructions to install knative serving.](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/)
 
+7. Install a networking layer. Currently lithops supports **Istio**. [Follow these instructions to install Istio.](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#install-a-networking-layer)
+
 
 ### Option 2 (IBM IKS or any other Kubernetes Cluster):
 
 4. Install Kubernetes >= v1.16 and make sure the *kubectl* client is running.
 
 6. [Follow this instructions to install knative serving.](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/)
+
+7. Install a networking layer. Currently Lithops supports **Istio**. [Follow these instructions to install Istio.](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#install-a-networking-layer)
 
 
 ## Configuration

--- a/examples/map.py
+++ b/examples/map.py
@@ -15,7 +15,7 @@ def my_map_function(id, x):
 
 if __name__ == "__main__":
     iterdata = [1, 2, 3, 4]
-    fexec = lithops.FunctionExecutor()
+    fexec = lithops.FunctionExecutor(backend='knative')
     fexec.map(my_map_function, iterdata)
     print(fexec.get_result())
     fexec.clean()

--- a/examples/map.py
+++ b/examples/map.py
@@ -15,7 +15,7 @@ def my_map_function(id, x):
 
 if __name__ == "__main__":
     iterdata = [1, 2, 3, 4]
-    fexec = lithops.FunctionExecutor(backend='knative')
+    fexec = lithops.FunctionExecutor()
     fexec.map(my_map_function, iterdata)
     print(fexec.get_result())
     fexec.clean()

--- a/lithops/config.py
+++ b/lithops/config.py
@@ -179,14 +179,10 @@ def default_config(config_data=None, config_overwrite={}, load_storage_config=Tr
         if 'runtime' not in config_data[c.LOCALHOST]:
             config_data[backend]['runtime'] = c.LOCALHOST_RUNTIME_DEFAULT
 
-        verify_runtime_name(config_data[backend]['runtime'])
-
     elif mode == c.SERVERLESS:
         logger.debug("Loading Serverless backend module: {}".format(backend))
         cb_config = importlib.import_module('lithops.serverless.backends.{}.config'.format(backend))
         cb_config.load_config(config_data)
-
-        verify_runtime_name(config_data[backend]['runtime'])
 
     elif mode == c.STANDALONE:
         if c.STANDALONE not in config_data or \
@@ -215,8 +211,6 @@ def default_config(config_data=None, config_overwrite={}, load_storage_config=Tr
 
         if 'runtime' not in config_data[c.STANDALONE]:
             config_data[c.STANDALONE]['runtime'] = c.SA_RUNTIME
-
-        verify_runtime_name(config_data[c.STANDALONE]['runtime'])
 
     if 'monitoring' not in config_data['lithops']:
         config_data['lithops']['monitoring'] = c.MONITORING_DEFAULT

--- a/lithops/constants.py
+++ b/lithops/constants.py
@@ -20,7 +20,7 @@ import tempfile
 
 LOGGER_LEVEL = 'info'
 LOGGER_STREAM = 'ext://sys.stderr'
-LOGGER_FORMAT = "%(asctime)s\t[%(levelname)s] %(filename)s:%(lineno)s -- %(message)s"
+LOGGER_FORMAT = "%(asctime)s [%(levelname)s] %(filename)s:%(lineno)s -- %(message)s"
 LOGGER_FORMAT_SHORT = "[%(levelname)s] %(filename)s:%(lineno)s -- %(message)s"
 LOGGER_LEVEL_CHOICES = ["debug", "info", "warning", "error", "critical"]
 

--- a/lithops/invokers.py
+++ b/lithops/invokers.py
@@ -27,7 +27,7 @@ from concurrent.futures import ThreadPoolExecutor
 from lithops.future import ResponseFuture
 from lithops.config import extract_storage_config
 from lithops.version import __version__ as lithops_version
-from lithops.utils import version_str, is_lithops_worker, iterchunks
+from lithops.utils import verify_runtime_name, version_str, is_lithops_worker, iterchunks
 from lithops.constants import LOGGER_LEVEL, LOGS_DIR,\
     LOCALHOST, SERVERLESS, STANDALONE
 from lithops.util.metrics import PrometheusExporter
@@ -85,8 +85,11 @@ class Invoker:
         self.backend = self.config['lithops']['backend']
         self.customized_runtime = self.config['lithops'].get('customized_runtime', False)
 
-        self.runtime_name = self.config[self.backend]['runtime']
-        self.max_workers = self.config[self.backend].get('max_workers')
+        self.runtime_info = self.compute_handler.get_runtime_info()
+        self.runtime_name = self.runtime_info['runtime_name']
+        self.max_workers = self.runtime_info['max_workers']
+
+        verify_runtime_name(self.runtime_name)
 
         logger.debug(f'ExecutorID {self.executor_id} - Invoker initialized.'
                      f' Max workers: {self.max_workers}')
@@ -96,14 +99,10 @@ class Invoker:
         Return the runtime metadata
         """
         if self.mode == SERVERLESS:
-            runtime_memory = runtime_memory or self.config[self.backend].get('runtime_memory')
-            runtime_timeout = self.config[self.backend].get('runtime_timeout')
-        elif self.mode == STANDALONE:
-            runtime_memory = None
-            runtime_timeout = self.config[STANDALONE]['hard_dismantle_timeout']
-        elif self.mode == LOCALHOST:
-            runtime_memory = None
-            runtime_timeout = None
+            runtime_memory = runtime_memory or self.runtime_info['runtime_memory']
+        else:
+            runtime_memory = self.runtime_info['runtime_memory']
+        runtime_timeout = self.runtime_info['runtime_timeout']
 
         msg = ('ExecutorID {} | JobID {} - Selected Runtime: {} '
                .format(self.executor_id, job_id, self.runtime_name))

--- a/lithops/invokers.py
+++ b/lithops/invokers.py
@@ -98,10 +98,8 @@ class Invoker:
         """
         Return the runtime metadata
         """
-        if self.mode == SERVERLESS:
-            runtime_memory = runtime_memory or self.runtime_info['runtime_memory']
-        else:
-            runtime_memory = self.runtime_info['runtime_memory']
+        runtime_memory = runtime_memory or self.runtime_info['runtime_memory'] \
+            if self.mode == SERVERLESS else self.runtime_info['runtime_memory']
         runtime_timeout = self.runtime_info['runtime_timeout']
 
         msg = ('ExecutorID {} | JobID {} - Selected Runtime: {} '

--- a/lithops/localhost/localhost.py
+++ b/lithops/localhost/localhost.py
@@ -146,6 +146,20 @@ class LocalhostHandler:
         runtime_key = os.path.join('localhost', env_type, runtime_name.strip("/"))
 
         return runtime_key
+    
+    def get_runtime_info(self):
+        """
+        Method that returns a dictionary with all the relevant runtime information
+        set in config
+        """
+        runtime_info = {
+            'runtime_name': self.config['runtime'],
+            'runtime_memory': None,
+            'runtime_timeout': None,
+            'max_workers': self.config['max_workers'],
+        }
+
+        return runtime_info
 
     def get_backend_type(self):
         """

--- a/lithops/serverless/backends/code_engine/code_engine.py
+++ b/lithops/serverless/backends/code_engine/code_engine.py
@@ -27,7 +27,7 @@ import yaml
 from kubernetes import client, config, watch
 from kubernetes.client.rest import ApiException
 
-from lithops.utils import version_str, dict_to_b64str, is_lithops_worker
+from lithops.utils import get_docker_username, version_str, dict_to_b64str, is_lithops_worker
 from lithops.version import __version__
 from lithops.utils import create_handler_zip
 from lithops.constants import COMPUTE_CLI_MSG, JOBS_PREFIX
@@ -520,6 +520,33 @@ class CodeEngineBackend:
         runtime_key = os.path.join(self.name, self.region, self.namespace, jobdef_name)
 
         return runtime_key
+    
+    def get_runtime_info(self):
+        """
+        Method that returns all the relevant information about the runtime set
+        in config
+        """
+        if 'runtime' not in self.code_engine_config:
+            if not ce_config.DOCKER_PATH:
+                raise Exception('docker command not found. Install docker or use '
+                                'an already built runtime')
+            if 'docker_user' not in self.code_engine_config:
+                self.code_engine_config['docker_user'] = get_docker_username()
+            if not self.code_engine_config['docker_user']:
+                raise Exception('You must execute "docker login" or provide "docker_user" '
+                                'param in config under "code_engine" section')
+
+            self.code_engine_config['runtime'] = self._get_default_runtime_image_name()
+        
+        runime_info = {
+            'runtime_name': self.k8s_config['runtime_name'],
+            'runtime_cpu': self.k8s_config['runtime_cpu'],
+            'runtime_memory': self.k8s_config['runtime_memory'],
+            'runtime_timeout': self.k8s_config['runtime_timeout'],
+            'max_workers': self.k8s_config['max_workers'],
+        }
+
+        return runime_info
 
     @retry_on_except
     def _job_def_exists(self, jobdef_name):

--- a/lithops/serverless/backends/code_engine/code_engine.py
+++ b/lithops/serverless/backends/code_engine/code_engine.py
@@ -539,11 +539,11 @@ class CodeEngineBackend:
             self.code_engine_config['runtime'] = self._get_default_runtime_image_name()
         
         runime_info = {
-            'runtime_name': self.k8s_config['runtime_name'],
-            'runtime_cpu': self.k8s_config['runtime_cpu'],
-            'runtime_memory': self.k8s_config['runtime_memory'],
-            'runtime_timeout': self.k8s_config['runtime_timeout'],
-            'max_workers': self.k8s_config['max_workers'],
+            'runtime_name': self.code_engine_config['runtime_name'],
+            'runtime_cpu': self.code_engine_config['runtime_cpu'],
+            'runtime_memory': self.code_engine_config['runtime_memory'],
+            'runtime_timeout': self.code_engine_config['runtime_timeout'],
+            'max_workers': self.code_engine_config['max_workers'],
         }
 
         return runime_info

--- a/lithops/serverless/backends/code_engine/code_engine.py
+++ b/lithops/serverless/backends/code_engine/code_engine.py
@@ -160,8 +160,12 @@ class CodeEngineBackend:
         return '{}--{}mb'.format(runtime_name, runtime_memory)
 
     def _get_default_runtime_image_name(self):
+        python_version = version_str(sys.version_info).replace('.', '')
+        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
+        img = '{}-v{}:{}'.format(ce_config.RUNTIME_NAME, python_version, revision)
+        
         if 'runtime' in self.code_engine_config:
-            return '{}-v{}:{}'.format(ce_config.RUNTIME_NAME, python_version, revision)
+            return img
 
         if 'docker_user' not in self.code_engine_config:
             self.code_engine_config['docker_user'] = get_docker_username()
@@ -169,10 +173,7 @@ class CodeEngineBackend:
             raise Exception('You must execute "docker login" or provide "docker_user" '
                             'param in config under "code_engine" section')
 
-        docker_user = self.code_engine_config['docker_user']
-        python_version = version_str(sys.version_info).replace('.', '')
-        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
-        return '{}/{}-v{}:{}'.format(docker_user, ce_config.RUNTIME_NAME, python_version, revision)
+        return f'{self.code_engine_config["docker_user"]}/{img}'
 
     def _delete_function_handler_zip(self):
         os.remove(ce_config.FH_ZIP_LOCATION)

--- a/lithops/serverless/backends/code_engine/code_engine.py
+++ b/lithops/serverless/backends/code_engine/code_engine.py
@@ -160,11 +160,15 @@ class CodeEngineBackend:
         return '{}--{}mb'.format(runtime_name, runtime_memory)
 
     def _get_default_runtime_image_name(self):
+        if 'runtime' in self.code_engine_config:
+            return '{}-v{}:{}'.format(ce_config.RUNTIME_NAME, python_version, revision)
+
         if 'docker_user' not in self.code_engine_config:
             self.code_engine_config['docker_user'] = get_docker_username()
         if not self.code_engine_config['docker_user']:
             raise Exception('You must execute "docker login" or provide "docker_user" '
                             'param in config under "code_engine" section')
+
         docker_user = self.code_engine_config['docker_user']
         python_version = version_str(sys.version_info).replace('.', '')
         revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')

--- a/lithops/serverless/backends/code_engine/config.py
+++ b/lithops/serverless/backends/code_engine/config.py
@@ -156,21 +156,6 @@ def load_config(config_data):
         if key not in config_data['code_engine']:
             config_data['code_engine'][key] = DEFAULT_CONFIG_KEYS[key]
 
-    if 'runtime' not in config_data['code_engine']:
-        if not DOCKER_PATH:
-            raise Exception('docker command not found. Install docker or use '
-                            'an already built runtime')
-        if 'docker_user' not in config_data['code_engine']:
-            config_data['code_engine']['docker_user'] = get_docker_username()
-        if not config_data['code_engine']['docker_user']:
-            raise Exception('You must execute "docker login" or provide "docker_user" '
-                            'param in config under "code_engine" section')
-        docker_user = config_data['code_engine']['docker_user']
-        python_version = version_str(sys.version_info).replace('.', '')
-        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
-        runtime_name = '{}/{}-v{}:{}'.format(docker_user, RUNTIME_NAME, python_version, revision)
-        config_data['code_engine']['runtime'] = runtime_name
-
     runtime_cpu = config_data['code_engine']['runtime_cpu']
     if runtime_cpu not in VALID_CPU_VALUES:
         raise Exception('{} is an invalid runtime cpu value. Set one of: '

--- a/lithops/serverless/backends/k8s/config.py
+++ b/lithops/serverless/backends/k8s/config.py
@@ -120,18 +120,3 @@ def load_config(config_data):
     for key in DEFAULT_CONFIG_KEYS:
         if key not in config_data['k8s']:
             config_data['k8s'][key] = DEFAULT_CONFIG_KEYS[key]
-
-    if 'runtime' not in config_data['k8s']:
-        if not DOCKER_PATH:
-            raise Exception('docker command not found. Install docker or use '
-                            'an already built runtime')
-        if 'docker_user' not in config_data['k8s']:
-            config_data['k8s']['docker_user'] = get_docker_username()
-        if not config_data['k8s']['docker_user']:
-            raise Exception('You must execute "docker login" or provide "docker_user" '
-                            'param in config under "k8s" section')
-        docker_user = config_data['k8s']['docker_user']
-        python_version = version_str(sys.version_info).replace('.', '')
-        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
-        runtime_name = '{}/{}-v{}:{}'.format(docker_user, RUNTIME_NAME, python_version, revision)
-        config_data['k8s']['runtime'] = runtime_name

--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -88,7 +88,12 @@ class KubernetesBackend:
         return '{}--{}mb'.format(runtime_name, runtime_memory)
 
     def _get_default_runtime_image_name(self):
-        docker_user = self.k8s_config.get('docker_user')
+        if 'docker_user' not in self.k8s_config:
+            self.k8s_config['docker_user'] = get_docker_username()
+        if not self.k8s_config['docker_user']:
+            raise Exception('You must execute "docker login" or provide "docker_user" '
+                            'param in config under "k8s" section')
+        docker_user = self.k8s_config['docker_user']
         python_version = version_str(sys.version_info).replace('.', '')
         revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
         return '{}/{}-v{}:{}'.format(docker_user, k8s_config.RUNTIME_NAME, python_version, revision)
@@ -100,8 +105,11 @@ class KubernetesBackend:
         """
         Builds a new runtime from a Docker file and pushes it to the Docker hub
         """
-        logger.debug('Building new docker image from Dockerfile')
-        logger.debug('Docker image name: {}'.format(docker_image_name))
+        logger.info(f'Building new docker image: {docker_image_name}')
+
+        if not k8s_config.DOCKER_PATH:
+            raise Exception('"docker" command not found. Install docker or use '
+                            'an already built runtime')
 
         entry_point = os.path.join(os.path.dirname(__file__), 'entry_point.py')
         create_handler_zip(k8s_config.FH_ZIP_LOCATION, entry_point, 'lithopsentry.py')
@@ -137,18 +145,14 @@ class KubernetesBackend:
         """
         Builds the default runtime
         """
-        if os.system('{} --version >{} 2>&1'.format(k8s_config.DOCKER_PATH, os.devnull)) == 0:
-            # Build default runtime using local dokcer
-            python_version = version_str(sys.version_info)
-            dockerfile = "Dockefile.default-k8s-runtime"
-            with open(dockerfile, 'w') as f:
-                f.write("FROM python:{}-slim-buster\n".format(python_version))
-                f.write(k8s_config.DOCKERFILE_DEFAULT)
-            self.build_runtime(default_runtime_img_name, dockerfile)
-            os.remove(dockerfile)
-        else:
-            raise Exception('docker command not found. Install docker or use '
-                            'an already built runtime')
+        # Build default runtime using local dokcer
+        python_version = version_str(sys.version_info)
+        dockerfile = "Dockefile.default-k8s-runtime"
+        with open(dockerfile, 'w') as f:
+            f.write("FROM python:{}-slim-buster\n".format(python_version))
+            f.write(k8s_config.DOCKERFILE_DEFAULT)
+        self.build_runtime(default_runtime_img_name, dockerfile)
+        os.remove(dockerfile)
 
     def _create_container_registry_secret(self):
         """
@@ -456,19 +460,10 @@ class KubernetesBackend:
         in config
         """
         if 'runtime' not in self.k8s_config:
-            if not k8s_config.DOCKER_PATH:
-                raise Exception('docker command not found. Install docker or use '
-                                'an already built runtime')
-            if 'docker_user' not in self.k8s_config:
-                self.k8s_config['docker_user'] = get_docker_username()
-            if not self.k8s_config['docker_user']:
-                raise Exception('You must execute "docker login" or provide "docker_user" '
-                                'param in config under "k8s" section')
-
             self.k8s_config['runtime'] = self._get_default_runtime_image_name()
         
         runime_info = {
-            'runtime_name': self.k8s_config['runtime_name'],
+            'runtime_name': self.k8s_config['runtime'],
             'runtime_cpu': self.k8s_config['runtime_cpu'],
             'runtime_memory': self.k8s_config['runtime_memory'],
             'runtime_timeout': self.k8s_config['runtime_timeout'],

--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -88,11 +88,15 @@ class KubernetesBackend:
         return '{}--{}mb'.format(runtime_name, runtime_memory)
 
     def _get_default_runtime_image_name(self):
+        if 'runtime' in self.k8s_config:
+            return '{}-v{}:{}'.format(k8s_config.RUNTIME_NAME, python_version, revision)
+
         if 'docker_user' not in self.k8s_config:
             self.k8s_config['docker_user'] = get_docker_username()
         if not self.k8s_config['docker_user']:
             raise Exception('You must execute "docker login" or provide "docker_user" '
                             'param in config under "k8s" section')
+
         docker_user = self.k8s_config['docker_user']
         python_version = version_str(sys.version_info).replace('.', '')
         revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')

--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -88,8 +88,12 @@ class KubernetesBackend:
         return '{}--{}mb'.format(runtime_name, runtime_memory)
 
     def _get_default_runtime_image_name(self):
+        python_version = version_str(sys.version_info).replace('.', '')
+        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
+        img = '{}-v{}:{}'.format(k8s_config.RUNTIME_NAME, python_version, revision)
+
         if 'runtime' in self.k8s_config:
-            return '{}-v{}:{}'.format(k8s_config.RUNTIME_NAME, python_version, revision)
+            return img
 
         if 'docker_user' not in self.k8s_config:
             self.k8s_config['docker_user'] = get_docker_username()
@@ -97,10 +101,7 @@ class KubernetesBackend:
             raise Exception('You must execute "docker login" or provide "docker_user" '
                             'param in config under "k8s" section')
 
-        docker_user = self.k8s_config['docker_user']
-        python_version = version_str(sys.version_info).replace('.', '')
-        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
-        return '{}/{}-v{}:{}'.format(docker_user, k8s_config.RUNTIME_NAME, python_version, revision)
+        return f'{self.k8s_config["docker_user"]}/{img}'
 
     def _delete_function_handler_zip(self):
         os.remove(k8s_config.FH_ZIP_LOCATION)

--- a/lithops/serverless/backends/knative/config.py
+++ b/lithops/serverless/backends/knative/config.py
@@ -16,10 +16,8 @@
 #
 
 import os
-import sys
 import shutil
 from lithops.version import __version__
-from lithops.utils import version_str, get_docker_username
 
 RUNTIME_NAME = 'lithops-knative'
 
@@ -224,18 +222,3 @@ def load_config(config_data):
     if 'git_rev' not in config_data['knative']:
         revision = 'master' if 'dev' in __version__ else __version__
         config_data['knative']['git_rev'] = revision
-
-    if 'runtime' not in config_data['knative']:
-        if not DOCKER_PATH:
-            raise Exception('docker command not found. Install docker or use '
-                            'an already built runtime')
-        if 'docker_user' not in config_data['knative']:
-            config_data['knative']['docker_user'] = get_docker_username()
-        if not config_data['knative']['docker_user']:
-            raise Exception('You must provide "docker_user" param in config '
-                            'or execute "docker login"')
-        docker_user = config_data['knative']['docker_user']
-        python_version = version_str(sys.version_info).replace('.', '')
-        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
-        runtime_name = '{}/{}-v{}:{}'.format(docker_user, RUNTIME_NAME, python_version, revision)
-        config_data['knative']['runtime'] = runtime_name

--- a/lithops/serverless/backends/knative/knative.py
+++ b/lithops/serverless/backends/knative/knative.py
@@ -132,8 +132,12 @@ class KnativeServingBackend:
         return image_name, int(memory.replace('mb', ''))
 
     def _get_default_runtime_image_name(self):
+        python_version = version_str(sys.version_info).replace('.', '')
+        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
+        img = '{}-v{}:{}'.format(kconfig.RUNTIME_NAME, python_version, revision)
+
         if 'runtime' in self.knative_config:
-            return '{}-v{}:{}'.format(kconfig.RUNTIME_NAME, python_version, revision)
+            return img
     
         if 'docker_user' not in self.knative_config:
             self.knative_config['docker_user'] = get_docker_username()
@@ -141,10 +145,7 @@ class KnativeServingBackend:
             raise Exception('You must execute "docker login" or provide "docker_user" '
                             'param in config under "knative" section')
 
-        docker_user = self.knative_config['docker_user']
-        python_version = version_str(sys.version_info).replace('.', '')
-        revision = 'latest' if 'dev' in __version__ else __version__.replace('.', '')
-        return '{}/{}-v{}:{}'.format(docker_user, kconfig.RUNTIME_NAME, python_version, revision)
+        return f'{self.knative_config["docker_user"]}/{img}'
 
     def _get_service_host(self, service_name):
         """

--- a/lithops/serverless/serverless.py
+++ b/lithops/serverless/serverless.py
@@ -96,7 +96,7 @@ class ServerlessHandler:
         Wrapper method to list deployed runtime in the compute backend
         """
         return self.backend.list_runtimes(runtime_name)
-        
+
     def get_runtime_key(self, runtime_name, memory):
         """
         Wrapper method that returns a formated string that represents the runtime key.

--- a/lithops/serverless/serverless.py
+++ b/lithops/serverless/serverless.py
@@ -96,7 +96,7 @@ class ServerlessHandler:
         Wrapper method to list deployed runtime in the compute backend
         """
         return self.backend.list_runtimes(runtime_name)
-
+        
     def get_runtime_key(self, runtime_name, memory):
         """
         Wrapper method that returns a formated string that represents the runtime key.
@@ -104,6 +104,23 @@ class ServerlessHandler:
         into the storage
         """
         return self.backend.get_runtime_key(runtime_name, memory)
+
+    def get_runtime_info(self):
+        """
+        Wrapper method that returns a dictionary with all the runtime information
+        set in config
+        """
+        if hasattr(self.backend, 'get_runtime_info'):
+            return self.backend.get_runtime_info()
+
+        runtime_info = {
+            'runtime_name': self.config[self.backend_name]['runtime'],
+            'runtime_memory': self.config[self.backend_name]['runtime_memory'],
+            'runtime_timeout': self.config[self.backend_name]['runtime_timeout'],
+            'max_workers': self.config[self.backend_name]['max_workers'],
+        }
+
+        return runtime_info
 
     def get_backend_type(self):
         """

--- a/lithops/standalone/standalone.py
+++ b/lithops/standalone/standalone.py
@@ -400,6 +400,18 @@ class StandaloneHandler:
         store modules preinstalls into the storage
         """
         return self.backend.get_runtime_key(runtime_name)
+    
+    def get_runtime_info(self):
+        """
+        Method that returns a dictionary with all the runtime information
+        set in config
+        """
+        runtime_info = {
+            'runtime_name': self.config['runtime'],
+            'runtime_memory': None,
+            'runtime_timeout': self.config['hard_dismantle_timeout'],
+            'max_workers': self.config[self.backend_name]['max_workers'],
+        }
 
     def get_backend_type(self):
         """

--- a/lithops/utils.py
+++ b/lithops/utils.py
@@ -350,10 +350,16 @@ def b64str_to_bytes(str_data):
 
 def get_docker_username():
     user = None
-    cmd = "{} info".format(shutil.which('docker'))
-    docker_user_info = sp.check_output(cmd, shell=True,
-                                       encoding='UTF-8',
-                                       stderr=sp.STDOUT)
+    docker_path = shutil.which('docker')
+    
+    if not docker_path:
+        return None
+    
+    docker_user_info = sp.check_output(
+        f"{docker_path} info", shell=True,
+        encoding='UTF-8', stderr=sp.STDOUT
+    )
+
     for line in docker_user_info.splitlines():
         if 'Username' in line:
             _, useranme = line.strip().split(':')


### PR DESCRIPTION
Kubernetes backends (kubernetes, code_engine and knative) needs docker installed in the local machine to build the default runtime if no runtime is provided in config. In this sense, all these backends (config.py files) contains a block of logic that checks whether docker is installed or not. This is a limitation when using the `lithops cli`, since for almost all the `lithops cli` commands it is not needed to check whether docker is installed or not.

This patch moves the logic that checks if docker is installed within a method that it only called during the invocation.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

