### PR TITLE
Fix job summary for windows hosts

### DIFF
--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -612,7 +612,7 @@ class FunctionExecutor:
             if self.log_path:  # retrieve cloud_objects_n from last log file
                 cloud_objects_n += get_object_num()
             else:
-                self.log_path = os.path.join(constants.LOGS_DIR, datetime.now().strftime("%Y-%m-%d_%H:%M:%S.csv"))
+                self.log_path = os.path.join(constants.LOGS_DIR, datetime.now().strftime("%Y-%m-%d_%H-%M-%S.csv"))
             # override current logfile
             init()
 


### PR DESCRIPTION
Windows doesn't allow `:` in path files. Job summary csv file name contains `:`, so `FunctionExecutor.job_summary()` fails on windows hosts. This patch replaces `:` with `-` in the file name to avoid this problem.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

