### PR TITLE
Add python3.10 to the aws_lambda runtimes

### DIFF
--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -32,7 +32,8 @@ AVAILABLE_PY_RUNTIMES = {
     '3.6': 'python3.6',
     '3.7': 'python3.7' ,
     '3.8': 'python3.8' ,
-    '3.9': 'python3.9'
+    '3.9': 'python3.9' ,
+    '3.10': 'python3.10'
 }
 
 USER_RUNTIME_PREFIX = 'lithops.user_runtimes'

--- a/runtime/aws_lambda/Dockerfile.python310
+++ b/runtime/aws_lambda/Dockerfile.python310
@@ -1,0 +1,63 @@
+# Define custom function directory
+ARG FUNCTION_DIR="/function"
+
+FROM python:3.10-buster as build-image
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+
+# Install aws-lambda-cpp build dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  g++ \
+  make \
+  cmake \
+  unzip \
+  libcurl4-openssl-dev
+
+# Copy function code
+RUN mkdir -p ${FUNCTION_DIR}
+
+# Update pip
+RUN pip install --upgrade --ignore-installed pip wheel six setuptools
+
+# Install the function's dependencies
+RUN pip install --upgrade --no-cache-dir --ignore-installed\
+    --target ${FUNCTION_DIR} \
+        awslambdaric \
+        boto3 \
+        redis \
+        httplib2 \
+        requests \
+        numpy \
+        scipy \
+        pandas \
+        pika \
+        kafka-python \
+        cloudpickle \
+        ps-mem \
+        tblib
+
+
+FROM python:3.10-buster
+
+# Include global arg in this stage of the build
+ARG FUNCTION_DIR
+# Set working directory to function root directory
+WORKDIR ${FUNCTION_DIR}
+
+# Copy in the built dependencies
+COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
+
+# Add Lithops
+COPY lithops_lambda.zip ${FUNCTION_DIR}
+RUN unzip lithops_lambda.zip \
+    && rm lithops_lambda.zip \
+    && mkdir handler \
+    && touch handler/__init__.py \
+    && mv entry_point.py handler/
+
+# Put your dependencies here, using RUN pip install... or RUN apt install...
+
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+CMD [ "handler.entry_point.lambda_handler" ]


### PR DESCRIPTION
Currently python3.10 is not supported by aws_lambda (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) but it is possible to have a working runtime with python3.10 if built with Docker:

```
$ lithops runtime build -f MyDockerfile -b aws_lambda my-container-runtime-name
```

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

