### PR TITLE
Check that methods have functions in serialize.py

### DIFF
--- a/lithops/job/serialize.py
+++ b/lithops/job/serialize.py
@@ -100,7 +100,7 @@ class SerializeIndependent:
         seen = set()
         mods = set()
 
-        if inspect.isfunction(obj) or inspect.ismethod(obj):
+        if inspect.isfunction(obj) or (inspect.ismethod(obj) and inspect.isfunction(obj.__func__)):
             # The obj is the user's function
             worklist.append(obj)
 
@@ -116,14 +116,14 @@ class SerializeIndependent:
                         # it is a user defined class
                         members = inspect.getmembers(param)
                         for k, v in members:
-                            if inspect.ismethod(v):
+                            if inspect.ismethod(v) and inspect.isfunction(v.__func__):
                                 worklist.append(v)
         else:
             # The obj is the user's function but in form of a class
             members = inspect.getmembers(obj)
             found_methods = []
             for k, v in members:
-                if inspect.ismethod(v):
+                if inspect.ismethod(v) and inspect.isfunction(v.__func__):
                     found_methods.append(k)
                     worklist.append(v)
             if "__call__" not in found_methods:


### PR DESCRIPTION
The `inspect` built-in python module has the following [code](https://github.com/python/cpython/blob/2fe016fbba7c3b8ec9c759221175971a3f235a68/Lib/inspect.py#L1554):

``` python
def getclosurevars(func):
   
    if ismethod(func):
        func = func.__func__

    if not isfunction(func):
        raise TypeError("{!r} is not a Python function".format(func))
    ...
```
And the function `getclosurevars` is [used in lithops](https://github.com/lithops-cloud/lithops/blob/d2d2a83527671d64a445411bc47843b308095b87/lithops/job/serialize.py#L138) with each element of `worklist` in [`SerializeIndependent._module_inspect`](https://github.com/lithops-cloud/lithops/blob/d2d2a83527671d64a445411bc47843b308095b87/lithops/job/serialize.py#L95).

This PR checks each method appended to `worklist` to be sure that its `__func__` are python functions. With these checks, we can be sure that no `TypeError` will be raised when working with methods. 

This bug has been discovered using the following code with lithops 2.6.0 and Sage 9.5 and python 3.10:

``` python
from sage.all_cmdline import Integer  
import lithops

_sage_const_7 = Integer(7)

def my_map_function(x):
    return x + _sage_const_7

iterdata = [Integer(1) , Integer(2) , Integer(3) , Integer(4) ]
fexec = lithops.FunctionExecutor()
fexec.map(my_map_function, iterdata)
print(fexec.get_result())
fexec.clean()
```


P.S. I've run the tests, following the contributing guidelines, but it turns out that the current master branch fails on some tests. No more fails are added.



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

