### PR TITLE
[Google Cloud] Allow to use GOOGLE_APPLICATION_CREDENTIALS for service_credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [K8s] Append 'docker_server' as a prefix of the runtime
 - [Code Engine] Append 'docker_server' as a prefix of the runtime
 - [Knative] Append 'docker_server' as a prefix of the runtime
+- [Google Cloud] Allow to use GOOGLE_APPLICATION_CREDENTIALS for service_credentials
 - [Google Cloud Run] Allow CPU values <1, 6 and 8
 - [Alibaba Cloud Functions] Added Python 3.9 runtime compatibility
 - [Alibaba Cloud Functions] Allow to build a runtime from a custom requirements.txt file

--- a/docs/source/compute_config/gcp_cloudrun.md
+++ b/docs/source/compute_config/gcp_cloudrun.md
@@ -38,8 +38,8 @@ python3 -m install lithops[gcp]
     gcp:
         project_name : <PROJECT_ID>
         service_account : <SERVICE_ACCOUNT_EMAIL>
-        credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
         region : <REGION_NAME>
+        credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
 ```
 
 ## Summary of configuration keys for Google Cloud
@@ -50,8 +50,8 @@ python3 -m install lithops[gcp]
 |---|---|---|---|---|
 |gcp | project_name | |yes | Project id given by Google Cloud Platform in step 3 (e.g. lithops-876385) |
 |gcp | service_account | |yes | Service account email of the service account created on step 5 (e.g. `lithops-executor@lithops.iam.gserviceaccount.com`) |
-|gcp | credentials_path | |yes | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`) |
 |gcp | region | |yes | Region of the bucket created at step 8. Functions and pub/sub queue will be created in the same region (e.g. `us-east1`) |
+|gcp | credentials_path | | no | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`). Alternatively you can set `GOOGLE_APPLICATION_CREDENTIALS` environment variable. If not provided it will try to load the default credentials from the environment|
 
 ### Google Cloud Run
 |Group|Key|Default|Mandatory|Additional info|

--- a/docs/source/compute_config/gcp_functions.md
+++ b/docs/source/compute_config/gcp_functions.md
@@ -39,8 +39,8 @@ python3 -m install lithops[gcp]
     gcp:
         project_name : <PROJECT_ID>
         service_account : <SERVICE_ACCOUNT_EMAIL>
-        credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
         region : <REGION_NAME>
+        credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
 ```
  
 ## Summary of configuration keys for Google:
@@ -51,8 +51,8 @@ python3 -m install lithops[gcp]
 |---|---|---|---|---|
 |gcp | project_name | |yes | Project id given by Google Cloud Platform in step 3 (e.g. `lithops-876385`) |
 |gcp | service_account | |yes | Service account email of the service account created on step 5 (e.g. `lithops-executor@lithops.iam.gserviceaccount.com`) |
-|gcp | credentials_path | |yes | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`) |
 |gcp | region | |yes | Region of the bucket created at step 8. Functions and pub/sub queue will be created in the same region (e.g. `us-east1`) |
+|gcp | credentials_path | |yes | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`). Alternatively you can set `GOOGLE_APPLICATION_CREDENTIALS` environment variable. If not provided it will try to load the default credentials from the environment|
 
 ### Google Cloud Functions
 |Group|Key|Default|Mandatory|Additional info|

--- a/docs/source/storage_config/gcp_storage.md
+++ b/docs/source/storage_config/gcp_storage.md
@@ -39,8 +39,8 @@ $ python3 -m pip install lithops[gcp]
     gcp:
         project_name : <<PROJECT_ID>>
         service_account : <SERVICE_ACCOUNT_EMAIL>
-        credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
         region : <REGION_NAME>
+        credentials_path : <FULL_PATH_TO_CREDENTIALS_JSON>
 
     gcp_storage:
         storage_bucket: <BUCKET_NAME>
@@ -54,8 +54,8 @@ $ python3 -m pip install lithops[gcp]
 |---|---|---|---|---|
 |gcp | project_name | |yes | Project id given by Google Cloud Platform in step 3 (e.g. lithops-876385) |
 |gcp | service_account | |yes | Service account email of the service account created on step 5 (e.g. `lithops-executor@lithops.iam.gserviceaccount.com`) |
-|gcp | credentials_path | |yes | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`) |
 |gcp | region | |yes | Region of the bucket created at step 8. Functions and pub/sub queue will be created in the same region (e.g. `us-east1`) |
+|gcp | credentials_path | |no | **Absolute** path of your JSON key file downloaded in step 7 (e.g. `/home/myuser/lithops-invoker1234567890.json`). Alternatively you can set `GOOGLE_APPLICATION_CREDENTIALS` environment variable. If not provided it will try to load the default credentials from the environment |
 
 ### Google Cloud Storage
 |Group|Key|Default|Mandatory|Additional info|

--- a/lithops/serverless/backends/gcp_cloudrun/cloudrun.py
+++ b/lithops/serverless/backends/gcp_cloudrun/cloudrun.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from lib2to3.pgen2 import token
 import logging
 import httplib2
 import os

--- a/lithops/serverless/backends/gcp_cloudrun/cloudrun.py
+++ b/lithops/serverless/backends/gcp_cloudrun/cloudrun.py
@@ -14,22 +14,24 @@
 # limitations under the License.
 #
 
+from lib2to3.pgen2 import token
 import logging
 import httplib2
 import os
 import time
 import json
-
+import urllib
 import yaml
-
-from lithops import utils
-from lithops.constants import COMPUTE_CLI_MSG
-from lithops.version import __version__
-
+import google.auth
+import google.oauth2.id_token
 from google.oauth2 import service_account
 from google_auth_httplib2 import AuthorizedHttp
 from google.auth.transport.requests import AuthorizedSession
 from googleapiclient.discovery import build
+
+from lithops import utils
+from lithops.constants import COMPUTE_CLI_MSG
+from lithops.version import __version__
 
 from . import config
 
@@ -45,15 +47,18 @@ class GCPCloudRunBackend:
         self.name = 'gcp_cloudrun'
         self.type = 'faas'
         self.cr_config = cloudrun_config
-        self.credentials_path = cloudrun_config['credentials_path']
+        self.credentials_path = cloudrun_config.get('credentials_path')
         self.service_account = cloudrun_config['service_account']
         self.project_name = cloudrun_config['project_name']
         self.region = cloudrun_config['region']
 
-        self._invoker_sess = None
-        self._invoker_sess_route = '/'
+        self._api_resource = self._build_api_resource()
+
         self._service_url = None
-        self._api_resource = None
+        self._id_token = None
+
+        if self.credentials_path and os.path.isfile(self.credentials_path):
+            logger.debug(f'Getting GCP credentials from {self.credentials_path}')
 
         msg = COMPUTE_CLI_MSG.format('Google Cloud Run')
         logger.info(f"{msg} - Region: {self.region} - Project: {self.project_name}")
@@ -81,32 +86,33 @@ class GCPCloudRunBackend:
         """
         Instantiate and authorize admin discovery API session
         """
-        if self._api_resource is None:
-            logger.debug('Building admin API session')
+        logger.debug('Building admin API session')
+        if os.path.isfile(self.credentials_path):
             credentials = service_account.Credentials.from_service_account_file(self.credentials_path, scopes=SCOPES)
-            http = AuthorizedHttp(credentials, http=httplib2.Http())
-            self._api_resource = build(
-                'run', CLOUDRUN_API_VERSION,
-                http=http, cache_discovery=False,
-                client_options={
-                    'api_endpoint': f'https://{self.region}-run.googleapis.com'
-                }
-            )
-        return self._api_resource
+        else:
+            credentials, _ = google.auth.default(scopes=SCOPES)
+        http = AuthorizedHttp(credentials, http=httplib2.Http())
+        api_resource = build(
+            'run', CLOUDRUN_API_VERSION,
+            http=http, cache_discovery=False,
+            client_options={
+                'api_endpoint': f'https://{self.region}-run.googleapis.com'
+            }
+        )
 
-    def _build_invoker_sess(self, runtime_name, memory, route):
+        return api_resource
+
+    def _get_token(self, target):
         """
-        Instantiate and authorize invoker session for a specific service and route
+        Generates a connection token
         """
-        if self._invoker_sess is None or route != self._invoker_sess_route:
-            logger.debug('Building invoker session')
-            target = self._get_service_endpoint(runtime_name, memory) + route
-            credentials = (service_account
-                           .IDTokenCredentials
-                           .from_service_account_file(self.credentials_path, target_audience=target))
-            self._invoker_sess = AuthorizedSession(credentials)
-            self._invoker_sess_route = route
-        return self._invoker_sess
+        if not self._id_token:
+            if self.credentials_path and os.path.isfile(self.credentials_path):
+                os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = self.credentials_path
+            auth_req = google.auth.transport.requests.Request()
+            self._id_token = google.oauth2.id_token.fetch_id_token(auth_req, target)
+
+        return self._id_token
 
     def _get_service_endpoint(self, runtime_name, memory):
         """
@@ -115,10 +121,11 @@ class GCPCloudRunBackend:
         if self._service_url is None:
             logger.debug('Getting service endpoint')
             svc_name = self._format_service_name(runtime_name, memory)
-            res = self._build_api_resource().namespaces().services().get(
+            res = self._api_resource.namespaces().services().get(
                 name=f'namespaces/{self.project_name}/services/{svc_name}'
             ).execute()
             self._service_url = res['status']['url']
+
         return self._service_url
 
     def _format_image_name(self, runtime_name):
@@ -181,7 +188,9 @@ class GCPCloudRunBackend:
         job_id = payload.get('job_id')
         route = payload.get("service_route", '/')
 
-        sess = self._build_invoker_sess(runtime_name, memory, route)
+        target = self._get_service_endpoint(runtime_name, memory)
+        id_token = self._get_token(target)
+        print(id_token)
 
         if exec_id and job_id and call_id:
             logger.debug(f'ExecutorID {exec_id} | JobID {job_id} - Invoking function call {call_id}')
@@ -190,11 +199,12 @@ class GCPCloudRunBackend:
         else:
             logger.debug('Invoking function')
 
-        url = self._get_service_endpoint(runtime_name, memory) + route
-        res = sess.post(url=url, data=json.dumps(payload, default=str))
+        req = urllib.request.Request(target+route, data=json.dumps(payload, default=str).encode('utf-8'))
+        req.add_header("Authorization", f"Bearer {id_token}")
+        res = urllib.request.urlopen(req)
 
-        if res.status_code in (200, 202):
-            data = res.json()
+        if res.getcode() in (200, 202):
+            data = json.loads(res.read())
             if return_result:
                 return data
             return data["activationId"]
@@ -272,7 +282,7 @@ class GCPCloudRunBackend:
         container['resources']['requests']['cpu'] = str(self.cr_config['runtime_cpu'])
 
         logger.info(f"Creating runtime: {runtime_name}")
-        res = self._build_api_resource().namespaces().services().create(
+        res = self._api_resource.namespaces().services().create(
             parent=f'namespaces/{self.project_name}', body=svc_res
         ).execute()
 
@@ -283,7 +293,7 @@ class GCPCloudRunBackend:
         retry = 15
         logger.debug(f'Waiting {service_name} service to become ready')
         while not ready:
-            res = self._build_api_resource().namespaces().services().get(
+            res = self._api_resource.namespaces().services().get(
                 name=f'namespaces/{self.project_name}/services/{service_name}'
             ).execute()
 
@@ -314,7 +324,7 @@ class GCPCloudRunBackend:
         # Wait until the service is completely deleted
         while True:
             try:
-                res = self._build_api_resource().namespaces().services().get(
+                res = self._api_resource.namespaces().services().get(
                     name=f'namespaces/{self.project_name}/services/{service_name}'
                 ).execute()
                 time.sleep(1)
@@ -325,7 +335,7 @@ class GCPCloudRunBackend:
         service_name = self._format_service_name(runtime_name, memory)
         logger.info(f'Deleting runtime: {runtime_name} - {memory}MB')
         try:
-            self._build_api_resource().namespaces().services().delete(
+            self._api_resource.namespaces().services().delete(
                 name=f'namespaces/{self.project_name}/services/{service_name}'
             ).execute()
             self._wait_service_deleted(service_name)
@@ -343,7 +353,7 @@ class GCPCloudRunBackend:
     def list_runtimes(self, runtime_name='all'):
         logger.debug('Listing runtimes')
 
-        res = self._build_api_resource().namespaces().services().list(
+        res = self._api_resource.namespaces().services().list(
             parent=f'namespaces/{self.project_name}',
         ).execute()
 

--- a/lithops/serverless/backends/gcp_cloudrun/config.py
+++ b/lithops/serverless/backends/gcp_cloudrun/config.py
@@ -19,7 +19,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-REQ_PARAMS = ('project_name', 'service_account', 'credentials_path', 'region')
+REQ_PARAMS = ('project_name', 'service_account', 'region')
 
 DEFAULT_CONFIG_KEYS = {
     'runtime_timeout': 300,  # Default: 600 seconds => 10 minutes
@@ -80,6 +80,7 @@ RUN pip install --upgrade --ignore-installed setuptools six pip \
         cryptography \
         httplib2 \
         google-cloud-storage \
+        google-cloud-pubsub \
         google-api-python-client \
         gcsfs \
         google-auth
@@ -147,13 +148,15 @@ def load_config(config_data):
 
     for param in REQ_PARAMS:
         if param not in config_data['gcp']:
-            msg = "{} is mandatory under 'gcp' section of the configuration".format(REQ_PARAMS)
+            msg = f"{param} is mandatory under 'gcp' section of the configuration"
             raise Exception(msg)
 
-    config_data['gcp']['credentials_path'] = os.path.expanduser(config_data['gcp']['credentials_path'])
+    if 'credentials_path' not in config_data['gcp']:
+        if 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ:
+            config_data['gcp']['credentials_path'] = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
 
-    if not os.path.isfile(config_data['gcp']['credentials_path']):
-        raise Exception(f"Credentials file {config_data['gcp']['credentials_path']} not found")
+    if 'credentials_path' in config_data['gcp']:
+        config_data['gcp']['credentials_path'] = os.path.expanduser(config_data['gcp']['credentials_path'])
 
     for key in DEFAULT_CONFIG_KEYS:
         if key not in config_data['gcp_cloudrun']:

--- a/lithops/serverless/backends/gcp_functions/config.py
+++ b/lithops/serverless/backends/gcp_functions/config.py
@@ -35,7 +35,7 @@ AVAILABLE_PY_RUNTIMES = {'3.7': 'python37', '3.8': 'python38', '3.9': 'python39'
 
 USER_RUNTIMES_PREFIX = 'lithops.user_runtimes'
 
-REQ_PARAMS = ('project_name', 'service_account', 'credentials_path', 'region')
+REQ_PARAMS = ('project_name', 'service_account', 'region')
 
 DEFAULT_CONFIG_KEYS = {
     'runtime_timeout': 300,  # Default: 5 minutes
@@ -55,6 +55,7 @@ google-cloud
 google-cloud-storage
 google-cloud-pubsub
 google-auth
+google-api-python-client
 certifi
 chardet
 docutils
@@ -85,10 +86,12 @@ def load_config(config_data=None):
             msg = f"{param} is mandatory under 'gcp' section of the configuration"
             raise Exception(msg)
 
-    config_data['gcp']['credentials_path'] = os.path.expanduser(config_data['gcp']['credentials_path'])
+    if 'credentials_path' not in config_data['gcp']:
+        if 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ:
+            config_data['gcp']['credentials_path'] = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
 
-    if not os.path.isfile(config_data['gcp']['credentials_path']):
-        raise Exception(f"Credentials file {config_data['gcp']['credentials_path']} not found")
+    if 'credentials_path' in config_data['gcp']:
+        config_data['gcp']['credentials_path'] = os.path.expanduser(config_data['gcp']['credentials_path'])
 
     for key in DEFAULT_CONFIG_KEYS:
         if key not in config_data['gcp_functions']:

--- a/lithops/storage/backends/gcp_storage/config.py
+++ b/lithops/storage/backends/gcp_storage/config.py
@@ -17,7 +17,7 @@
 import os
 
 
-REQ_PARAMS = ('project_name', 'service_account', 'credentials_path', 'region')
+REQ_PARAMS = ('project_name', 'service_account', 'region')
 
 
 def load_config(config_data=None):
@@ -29,10 +29,12 @@ def load_config(config_data=None):
             msg = f"'{param}' is mandatory under 'gcp' section of the configuration"
             raise Exception(msg)
     
-    config_data['gcp']['credentials_path'] = os.path.expanduser(config_data['gcp']['credentials_path'])
+    if 'credentials_path' not in config_data['gcp']:
+        if 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ:
+            config_data['gcp']['credentials_path'] = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
 
-    if not os.path.isfile(config_data['gcp']['credentials_path']):
-        raise Exception(f"Credentials file {config_data['gcp']['credentials_path']} not found")
+    if 'credentials_path' in config_data['gcp']:
+        config_data['gcp']['credentials_path'] = os.path.expanduser(config_data['gcp']['credentials_path'])
 
     config_data['gcp_storage'].update(config_data['gcp'])
 

--- a/lithops/storage/backends/gcp_storage/gcp_storage.py
+++ b/lithops/storage/backends/gcp_storage/gcp_storage.py
@@ -34,10 +34,12 @@ TIMEOUT = 5
 class GCPStorageBackend:
     def __init__(self, gcp_storage_config):
         logger.debug("Creating GCP Storage client")
-        self.credentials_path = gcp_storage_config['credentials_path']
+        self.credentials_path = gcp_storage_config.get('credentials_path')
         try:  # Get credenitals from JSON file
             self.client = storage.Client.from_service_account_json(self.credentials_path)
+            logger.debug(f'Getting GCP credentials from {self.credentials_path}')
         except Exception:  # Get credentials from gcp function environment
+            logger.debug(f'Getting GCP credentials from the environment')
             self.client = storage.Client()
         msg = STORAGE_CLI_MSG.format('Google Cloud Storage')
         logger.info("{}".format(msg))


### PR DESCRIPTION
service_credential is no longer mandatory
if no service_credential, it will try to load GOOGLE_APPLICATION_CREDENTIALS
if none of the above, it will try to get the credentials from the GCP environment

#963 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

