### PR TITLE
Addition of ability to run Lithops on shared multi-user machines.

### DIFF
--- a/lithops/config.py
+++ b/lithops/config.py
@@ -61,6 +61,7 @@ def get_default_config_filename():
     First checks .lithops_config
     then checks LITHOPS_CONFIG_FILE environment variable
     then ~/.lithops/config
+    and as last resort the global configuration /etc/lithops/config
     """
     if 'LITHOPS_CONFIG_FILE' in os.environ:
         config_filename = os.environ['LITHOPS_CONFIG_FILE']
@@ -71,7 +72,9 @@ def get_default_config_filename():
     else:
         config_filename = c.CONFIG_FILE
         if not os.path.exists(config_filename):
-            return None
+            config_filename = c.CONFIG_FILE_GLOBAL
+            if not os.path.exists(config_filename):
+                return None
 
     return config_filename
 

--- a/lithops/constants.py
+++ b/lithops/constants.py
@@ -68,7 +68,7 @@ MAX_AGG_DATA_SIZE = 4  # 4MiB
 WORKER_PROCESSES_DEFAULT = 1
 
 TEMP_DIR = os.path.realpath(tempfile.gettempdir())
-LITHOPS_TEMP_DIR = os.path.join(TEMP_DIR, 'lithops')
+LITHOPS_TEMP_DIR = os.path.join(TEMP_DIR, 'lithops-' + os.getenv("USER"))
 JOBS_DIR = os.path.join(LITHOPS_TEMP_DIR, 'jobs')
 LOGS_DIR = os.path.join(LITHOPS_TEMP_DIR, 'logs')
 MODULES_DIR = os.path.join(LITHOPS_TEMP_DIR, 'modules')
@@ -85,6 +85,7 @@ HOME_DIR = os.path.expanduser('~')
 CONFIG_DIR = os.path.join(HOME_DIR, '.lithops')
 CACHE_DIR = os.path.join(CONFIG_DIR, 'cache')
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'config')
+CONFIG_FILE_GLOBAL = os.path.join("/etc", "lithops", "config")
 
 SERVERLESS_BACKENDS = [
     'ibm_cf',


### PR DESCRIPTION
The current behaviour of Lithops is to create an unqualified subdirectory in /tmp for tracking various bits of information. When more than one user one a machine run a globally installed framework, this causes permission issues:

$ lithops test
... [INFO] config.py:131 -- Lithops v2.7.2.dev0
...
Traceback (most recent call last):
...
PermissionError: [Errno 13] Permission denied: '/tmp/lithops/storage/lithops.jobs'
...
Traceback (most recent call last):
...
PermissionError: [Errno 13] Permission denied: '/tmp/lithops/cleaner/tmpkjj_17vq'

The patch fixes that by qualifying the directory with a username component. (Security versus comfort trade-off: Using the UID may be safer but is less readable than the $USER value.) Related to that, the patch also makes it possible to configure Lithops for all users without having to set LITHOPS_CONFIG_FILE, while still permitting them to override with their own configurations. The use of a default file in /etc follows conventions.

With this patch, Lithops becomes usable e.g. in classroom settings.

All but one unit tests pass. The one that bails out might be unrelated to the patch.

======================================================================
FAIL: test_storage_list_objects (lithops.tests.test_storage.TestStorage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/lithops-2.7.2.dev0-py3.10.egg/lithops/tests/test_storage.py", line 177, in test_storage_list_objects
    self.assertEqual(extract_keys(foo_objects), sorted([
AssertionError: Lists differ: ['__lithops.test/foo_baz', '__lithops.test/foo/baz', '__litho[46 chars]baz'] != ['__lithops.test/foo/bar/baz', '__lithops.test/foo/baz', '__l[46 chars]baz']

---

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

