### PR TITLE
Add additional arguments to pass to the reduce function in map_reduce()

### DIFF
--- a/lithops/executors.py
+++ b/lithops/executors.py
@@ -301,6 +301,7 @@ class FunctionExecutor:
         reduce_function: Callable,
         chunksize: Optional[int] = None,
         extra_args: Optional[Union[List[Any], Tuple[Any, ...], Dict[str, Any]]] = None,
+        extra_args_reduce: Optional[Union[List[Any], Tuple[Any, ...], Dict[str, Any]]] = None,
         extra_env: Optional[Dict[str, str]] = None,
         map_runtime_memory: Optional[int] = None,
         reduce_runtime_memory: Optional[int] = None,
@@ -321,6 +322,7 @@ class FunctionExecutor:
         :param reduce_function: The function to reduce over the futures
         :param chunksize: Split map_iteradata in chunks of this size. Lithops spawns 1 worker per resulting chunk. Default 1
         :param extra_args: Additional arguments to pass to function activation. Default None
+        :param extra_args_reduce: Additional arguments to pass to the reduce function activation. Default None
         :param extra_env: Additional environment variables for action environment. Default None
         :param map_runtime_memory: Memory to use to run the map function. Default None (loaded from config)
         :param reduce_runtime_memory: Memory to use to run the reduce function. Default None (loaded from config)
@@ -386,6 +388,7 @@ class FunctionExecutor:
             map_futures=map_futures,
             runtime_meta=runtime_meta,
             runtime_memory=reduce_runtime_memory,
+            extra_args=extra_args_reduce,
             obj_reduce_by_key=obj_reduce_by_key,
             extra_env=extra_env,
             include_modules=include_modules,

--- a/lithops/job/job.py
+++ b/lithops/job/job.py
@@ -114,7 +114,8 @@ def create_reduce_job(
     extra_env,
     include_modules,
     exclude_modules,
-    execution_timeout=None
+    execution_timeout=None,
+    extra_args=None
 ):
     """
     Wrapper to create a reduce job. Apply a function across all map futures.
@@ -137,7 +138,7 @@ def create_reduce_job(
         ext_env = extra_env.copy()
         ext_env.update(reduce_job_env)
 
-    iterdata = utils.verify_args(reduce_function, iterdata, None)
+    iterdata = utils.verify_args(reduce_function, iterdata, extra_args)
 
     return _create_job(
         config=config,


### PR DESCRIPTION
This change allows additional arguments to be passed to the reduce function.

For example:

```python
import lithops

args = [  # Init list of parameters for Lithops
    (1, 2),  # Args for function1
    (3, 4),  # Args for function2
    (5, 6),  # Args for function3
]  # End list of parameters for Lithops


def my_function(x, y, extra_param):
    print(f"Extra param: {extra_param}")
    return x + y


def my_reduce_function(results, extra_param):
    print(f"Extra param: {extra_param}")
    return sum(results)


if __name__ == "__main__":
    fexec = lithops.FunctionExecutor()
    fexec.map_reduce(my_function, args, my_reduce_function, extra_args=(1,), extra_args_reduce=(2,))
    print(fexec.get_result())

```
 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

