### PR TITLE
Check size of each iterdata element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [IBM COS] Changed 'access_key' config parameter to 'access_key_id' for compatibility
 - [IBM COS] Changed 'secret_key' config parameter to 'secret_access_key' for compatibility
 - [IBM] Improved token manager
+- [Core] Job creation now checks that each element in 'iterdata' is smaller than 8 KB
 
 ### Fixed
 - [IBM VPC & AWS EC2] Make sure only VMs from the given VPC are removed

--- a/lithops/job/job.py
+++ b/lithops/job/job.py
@@ -258,7 +258,10 @@ def _create_job(
 
     # Upload function and data
     upload_function = not config['lithops'].get('customized_runtime', False)
-    upload_data = not (len(str(data_strs[0])) * job.chunksize < 8 * 1204 and backend in FAAS_BACKENDS)
+    upload_data = not (
+            (len(str(data_str)) * job.chunksize < 8 * 1204 for data_str in data_strs)
+            and backend in FAAS_BACKENDS
+    )
 
     # Upload function and modules
     if upload_function:


### PR DESCRIPTION
Job creation only checks the size of the first element in `iterdata`.

I modified this check, and now checks all the elements in `iterdata`. In the case of an `iterdata` with large elements, the `all` function would return `False` immediately after checking the first element, so there shouldn't be any real performance degradation. 

What do you think @JosepSampe ?
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

