### PR TITLE
[MapReduce] Make 'results' variable name not mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [IBM COS] Changed 'secret_key' config parameter to 'secret_access_key' for compatibility
 - [IBM] Improved token manager
 - [Core] Job creation now checks that each element in 'iterdata' is smaller than 8 KB
+- [MapReduce] Make 'results' variable name not mandatory in the reduce function signature
 
 ### Fixed
 - [IBM VPC & AWS EC2] Make sure only VMs from the given VPC are removed

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -117,11 +117,11 @@ class JobRunner:
 
     def _wait_futures(self, data):
         logger.info('Reduce function: waiting for map results')
-        fut_list = data['results']
+        fut_list = list(data.values())[0]
         wait(fut_list, self.internal_storage, download_results=True)
         results = [f.result() for f in fut_list if f.done and not f.futures]
         fut_list.clear()
-        data['results'] = results
+        data[next(iter(data))] = results
 
     def _load_object(self, data):
         """


### PR DESCRIPTION
Fix #1091
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

