### PR TITLE
[AWS Lambda] Allow Python3.11 runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 - [AWS Lambda] Added support for python 3.10 runtimes
+- [AWS Lambda] Added support for python 3.11 runtimes
 - [Azure Functions] Added support for python 3.10 runtimes
 - [Aliyun Functions] Added support for python 3.10 runtimes
 - [Executor] Allow to set all the compute backend params programatically in the FunctionExecutor()

--- a/lithops/serverless/backends/aws_lambda/config.py
+++ b/lithops/serverless/backends/aws_lambda/config.py
@@ -35,7 +35,8 @@ AVAILABLE_PY_RUNTIMES = {
     '3.7': 'python3.7',
     '3.8': 'python3.8',
     '3.9': 'python3.9',
-    '3.10': 'python3.10'
+    '3.10': 'python3.10',
+    '3.11': 'python3.11'
 }
 
 USER_RUNTIME_PREFIX = 'lithops.user_runtimes'

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Scientific/Engineering',
         'Topic :: System :: Distributed Computing',


### PR DESCRIPTION
For https://github.com/lithops-cloud/lithops/issues/1132
Still need to be tested, but this should be enough
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

