### PR TITLE
fix create_partitions() failure with CloudObject inputs

### DIFF
--- a/lithops/job/partitioner.py
+++ b/lithops/job/partitioner.py
@@ -16,6 +16,7 @@
 #
 
 import os
+import sys 
 import logging
 import requests
 from concurrent.futures import ThreadPoolExecutor
@@ -52,11 +53,11 @@ def create_partitions(
     # first filter; decide if the iterdata elements are urls,
     # paths or object storage objects
     for elem in map_iterdata:
-        if elem['obj'].startswith('http'):
+        if str(elem['obj']).startswith('http'):
             # iterdata is a list of public urls
             urls.append(elem)
 
-        elif elem['obj'].startswith('/'):
+        elif str(elem['obj']).startswith('/'):
             # iterdata is a list of localhost paths or dirs
             paths.append(elem)
 


### PR DESCRIPTION
Very small fix for the case that the iterdata passed to create_partitions consists of CloudObjects, which leads to a failure ".startswith" at lines 56 and 60 


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

