### PR TITLE
[CLI] Fix lithops image commands

### DIFF
--- a/lithops/scripts/cli.py
+++ b/lithops/scripts/cli.py
@@ -767,6 +767,7 @@ def build_image(ctx, name, file, config, backend, region, debug, overwrite):
 
     config = load_yaml_config(config) if config else None
     config_ow = set_config_ow(backend=backend, region=region)
+    config_ow['backend']['exec_mode'] = 'create'
     config = default_config(config_data=config, config_overwrite=config_ow, load_storage_config=False)
 
     if config['lithops']['mode'] != STANDALONE:
@@ -796,6 +797,7 @@ def delete_image(ctx, name, config, backend, region, debug):
 
     config = load_yaml_config(config) if config else None
     config_ow = set_config_ow(backend=backend, region=region)
+    config_ow['backend']['exec_mode'] = 'create'
     config = default_config(config_data=config, config_overwrite=config_ow, load_storage_config=False)
 
     if config['lithops']['mode'] != STANDALONE:
@@ -821,6 +823,7 @@ def list_images(config, backend, region, debug):
 
     config = load_yaml_config(config) if config else None
     config_ow = set_config_ow(backend=backend, region=region)
+    config_ow['backend']['exec_mode'] = 'create'
     config = default_config(config_data=config, config_overwrite=config_ow, load_storage_config=False)
 
     if config['lithops']['mode'] != STANDALONE:


### PR DESCRIPTION
Make sure these commands work when no config is provided, since the default standalone exec mode is the consume, and in the consume mode it is mandatory a VM id in the config
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

