### PR TITLE
[Standalone] Changed default mode of execution from 'consume' to 'reuse'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [localhost] New localhost backend v2 to maximize resource utilization when multiple maps are executed from the same FunctionExecutor
 
 ### Changed
+- [Standalone] Changed default mode of execution from 'consume' to 'reuse'
 - [Joblib] Updated the joblib backend to make it compatible for newer versions of joblib
 - [AWS EC2] Changed default image name from "lithops-worker-default" to "lithops-ubuntu-jammy-22.04-amd64-server"
 - [IBM VPC] Changed default image name from "lithops-worker-default" to "lithops-ubuntu-22-04-3-minimal-amd64-1"

--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -72,7 +72,7 @@
     #singlesocket: <True/False> # Optional, default is False
 
     #runtime: <RUNTIME_NAME>
-    #exec_mode: consume
+    #exec_mode: reuse
     #auto_dismantle: True
     #pull_runtime: <false, true>
     #hard_dismantle_timeout: 3600
@@ -100,7 +100,7 @@
     #worker_processes: <WORKER_GRANULARITY> Default is 2
 
     #runtime: <RUNTIME_NAME>
-    #exec_mode: consume
+    #exec_mode: reuse
     #auto_dismantle: True
     #pull_runtime: <false, true>
     #hard_dismantle_timeout: 3600

--- a/docs/source/compute_config/aws_ec2.md
+++ b/docs/source/compute_config/aws_ec2.md
@@ -30,6 +30,7 @@ aws:
     secret_access_key: <AWS_SECRET_ACCESS_KEY>
 
 aws_ec2:
+    exec_mode: consume
     instance_id : <INSTANCE ID OF THE VM>
 ```
 
@@ -116,7 +117,7 @@ aws_ec2:
 |aws_ec2 | auto_dismantle | True |no | If False then the VM is not stopped automatically.|
 |aws_ec2 | soft_dismantle_timeout | 300 |no| Time in seconds to stop the VM instance after a job **completed** its execution |
 |aws_ec2 | hard_dismantle_timeout | 3600 | no | Time in seconds to stop the VM instance after a job **started** its execution |
-|aws_ec2 | exec_mode | consume | no | One of: **consume**, **create** or **reuse**. If set to  **create**, Lithops will automatically create new VMs for each map() call based on the number of elements in iterdata. If set to **reuse** will try to reuse running workers if exist |
+|aws_ec2 | exec_mode | reuse | no | One of: **consume**, **create** or **reuse**. If set to  **create**, Lithops will automatically create new VMs for each map() call based on the number of elements in iterdata. If set to **reuse** will try to reuse running workers if exist |
 |aws_ec2 | pull_runtime | False | no | If set to True, Lithops will execute the command `docker pull <runtime_name>` in each VSI before executing the a job (in case of using a docker runtime)|
 |aws_ec2 | workers_policy | permissive | no | One of: **permissive**, **strict**. If set to **strict** will force creation of required workers number |
 

--- a/docs/source/compute_config/azure_vms.md
+++ b/docs/source/compute_config/azure_vms.md
@@ -26,6 +26,7 @@ Edit your lithops config and add the relevant keys:
         subscription_id: <SUBSCRIPTION_ID>
 
     azure_vms:
+        exec_mode: consume
         instance_name: <VM_NAME>
         ssh_username: <SSH_USERNAME>
         ssh_key_filename: <SSH_KEY_PATH>
@@ -103,7 +104,7 @@ Edit your lithops config and add the relevant keys:
 |azure_vms | auto_dismantle | True |no | If False then the VM is not stopped automatically.|
 |azure_vms | soft_dismantle_timeout | 300 |no| Time in seconds to stop the VM instance after a job **completed** its execution |
 |azure_vms | hard_dismantle_timeout | 3600 | no | Time in seconds to stop the VM instance after a job **started** its execution |
-|azure_vms | exec_mode | consume | no | One of: **consume**, **create** or **reuse**. If set to  **create**, Lithops will automatically create new VMs for each map() call based on the number of elements in iterdata. If set to **reuse** will try to reuse running workers if exist |
+|azure_vms | exec_mode | reuse | no | One of: **consume**, **create** or **reuse**. If set to  **create**, Lithops will automatically create new VMs for each map() call based on the number of elements in iterdata. If set to **reuse** will try to reuse running workers if exist |
 |azure_vms | pull_runtime | False | no | If set to True, Lithops will execute the command `docker pull <runtime_name>` in each VSI before executing the a job (in case of using a docker runtime)|
 |azure_vms | workers_policy | permissive | no | One of: **permissive**, **strict**. If set to **strict** will force creation of required workers number |
 

--- a/docs/source/compute_config/code_engine.md
+++ b/docs/source/compute_config/code_engine.md
@@ -66,6 +66,7 @@ code_engine:
     docker_server    : us.icr.io  # Change-me if you have the CR in another region
     docker_user      : iamapikey
     docker_password  : <IBM IAM API KEY>
+    docker_namespace : <namespace>  # namespace name from https://cloud.ibm.com/registry/namespaces
 ```
 
 

--- a/docs/source/compute_config/ibm_vpc.md
+++ b/docs/source/compute_config/ibm_vpc.md
@@ -97,7 +97,7 @@ ibm_vpc:
 |ibm_vpc | auto_dismantle | True |no | If False then the VM is not stopped automatically.|
 |ibm_vpc | soft_dismantle_timeout | 300 |no| Time in seconds to stop the VM instance after a job **completed** its execution |
 |ibm_vpc | hard_dismantle_timeout | 3600 | no | Time in seconds to stop the VM instance after a job **started** its execution |
-|ibm_vpc | exec_mode | consume | no | One of: **consume**, **create** or **reuse**. If set to  **create**, Lithops will automatically create new VMs for each map() call based on the number of elements in iterdata. If set to **reuse** will try to reuse running workers if exist |
+|ibm_vpc | exec_mode | reuse | no | One of: **consume**, **create** or **reuse**. If set to  **create**, Lithops will automatically create new VMs for each map() call based on the number of elements in iterdata. If set to **reuse** will try to reuse running workers if exist |
 |ibm_vpc | pull_runtime | False | no | If set to True, Lithops will execute the command `docker pull <runtime_name>` in each VSI before executing the a job (in case of using a docker runtime)|
 |ibm_vpc | workers_policy | permissive | no | One of: **permissive**, **strict**. If set to **strict** will force creation of required workers number |
 |ibm_vpc | gpu | False | no | If True docker started with gpu support. Requires host to have neccessary hardware and software preconfigured and docker image runtime with gpu support specified |
@@ -118,6 +118,7 @@ Edit your lithops config and add the relevant keys:
 	  iam_api_key: <iam-api-key>
 
    ibm_vpc:
+      exec_mode: consume
       region   : <REGION>
       instance_id : <INSTANCE ID OF THE VM>
       floating_ip  : <FLOATING IP ADDRESS OF THE VM>

--- a/docs/source/compute_config/ibm_vpc.md
+++ b/docs/source/compute_config/ibm_vpc.md
@@ -56,6 +56,7 @@ ibm_vpc:
     docker_server    : us.icr.io  # Change-me if you have the CR in another region
     docker_user      : iamapikey
     docker_password  : <IBM IAM API KEY>
+    docker_namespace : <namespace>  # namespace name from https://cloud.ibm.com/registry/namespaces
 ```
 
 
@@ -115,7 +116,7 @@ Edit your lithops config and add the relevant keys:
 	  backend: ibm_vpc
 
    ibm:
-	  iam_api_key: <iam-api-key>
+      iam_api_key: <iam-api-key>
 
    ibm_vpc:
       exec_mode: consume

--- a/docs/source/compute_config/knative.md
+++ b/docs/source/compute_config/knative.md
@@ -92,6 +92,7 @@ knative:
     docker_server    : us.icr.io
     docker_user      : iamapikey
     docker_password  : <IBM IAM API KEY>
+    docker_namespace : <namespace>  # namespace name from https://cloud.ibm.com/registry/namespaces
 ```
 
 ## Summary of configuration keys for Knative:

--- a/docs/source/compute_config/kubernetes.md
+++ b/docs/source/compute_config/kubernetes.md
@@ -48,6 +48,7 @@ k8s:
     docker_server    : us.icr.io
     docker_user      : iamapikey
     docker_password  : <IBM IAM API KEY>
+    docker_namespace : <namespace>  # namespace name from https://cloud.ibm.com/registry/namespaces
 ```
 
 ## Summary of configuration keys for kubernetes:

--- a/lithops/constants.py
+++ b/lithops/constants.py
@@ -63,7 +63,7 @@ SA_DATA_FILE = os.path.join(SA_INSTALL_DIR, 'access.data')
 
 SA_DEFAULT_CONFIG_KEYS = {
     'runtime': 'python3',
-    'exec_mode': 'consume',
+    'exec_mode': 'reuse',
     'use_gpu': False,
     'start_timeout': 300,
     'pull_runtime': False,

--- a/lithops/scripts/cli.py
+++ b/lithops/scripts/cli.py
@@ -65,7 +65,6 @@ from lithops.storage import InternalStorage
 from lithops.serverless import ServerlessHandler
 from lithops.storage.utils import clean_bucket
 from lithops.standalone import StandaloneHandler
-from lithops.standalone.utils import StandaloneMode
 from lithops.localhost import LocalhostHandler
 
 
@@ -780,7 +779,6 @@ def build_image(ctx, name, file, config, backend, region, debug, overwrite):
 
     config = load_yaml_config(config) if config else None
     config_ow = set_config_ow(backend=backend, region=region)
-    config_ow['backend']['exec_mode'] = StandaloneMode.CREATE.value
     config = default_config(config_data=config, config_overwrite=config_ow, load_storage_config=False)
 
     if config['lithops']['mode'] != STANDALONE:
@@ -810,7 +808,6 @@ def delete_image(ctx, name, config, backend, region, debug):
 
     config = load_yaml_config(config) if config else None
     config_ow = set_config_ow(backend=backend, region=region)
-    config_ow['backend']['exec_mode'] = StandaloneMode.CREATE.value
     config = default_config(config_data=config, config_overwrite=config_ow, load_storage_config=False)
 
     if config['lithops']['mode'] != STANDALONE:
@@ -836,7 +833,6 @@ def list_images(config, backend, region, debug):
 
     config = load_yaml_config(config) if config else None
     config_ow = set_config_ow(backend=backend, region=region)
-    config_ow['backend']['exec_mode'] = StandaloneMode.CREATE.value
     config = default_config(config_data=config, config_overwrite=config_ow, load_storage_config=False)
 
     if config['lithops']['mode'] != STANDALONE:


### PR DESCRIPTION
The main reason of this change is that the `reuse` mode does not need config at all in the backend section, while the `consume` mode requires more parameters, so it makes more sense to define `exec_mode: consume` when there are more parameters in the config, instead of having to explicit set `exec_mode: reuse` alone in the backend section of the config.

At the same time, the are some cli commands (`lithops clean`, `lithops worker list`, `lithops job list` , `lithops image build`) that don't work because of the current default `consume` mode. With this change, they will all work by default without "tricks" in the code.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

