### PR TITLE
Fix deprecation warning in GCP storage for Blob.download_as_string()

### DIFF
--- a/lithops/storage/backends/gcp_storage/gcp_storage.py
+++ b/lithops/storage/backends/gcp_storage/gcp_storage.py
@@ -112,7 +112,7 @@ class GCPStorageBackend:
             stream.seek(0)  # Retrun to the initial buffer position
             return stream
         else:
-            return blob.download_as_string(start=start, end=end)
+            return blob.download_as_bytes(start=start, end=end)
 
     def upload_file(self, file_name, bucket, key=None, extra_args={}, config=None):
         """Upload a file


### PR DESCRIPTION
This fixes the following warning:

```
PendingDeprecationWarning: Blob.download_as_string() is deprecated and will be removed in future. Use Blob.download_as_bytes() instead.
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

