### PR TITLE
Add a mechanism to automatically retry failed tasks

### DIFF
--- a/lithops/retries.py
+++ b/lithops/retries.py
@@ -1,0 +1,208 @@
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from lithops import FunctionExecutor
+from lithops.future import ResponseFuture
+from lithops.wait import (
+    ALL_COMPLETED,
+    ALWAYS,
+    ANY_COMPLETED,
+    THREADPOOL_SIZE,
+    WAIT_DUR_SEC,
+)
+from six import reraise
+
+
+class RetryingFuture:
+    """
+    A wrapper around Lithops `ResponseFuture` that takes care of retries.
+    """
+
+    def __init__(
+        self,
+        response_future: ResponseFuture,
+        map_function: Callable[..., Any],
+        input: Any,
+        retries: Optional[int] = None,
+        **kwargs
+    ):
+        self.response_future = response_future
+        self.map_function = map_function
+        self.input = input
+        self.retries = retries or 0
+        self.map_kwargs = kwargs
+        self.failure_count = 0
+        self.cancelled = False
+
+    def _inc_failure_count(self):
+        self.failure_count += 1
+
+    def _should_retry(self):
+        return not self.cancelled and self.failure_count <= self.retries
+
+    def _retry(self, function_executor: FunctionExecutor):
+        inputs = [self.input]
+        futures_list = function_executor.map(
+            self.map_function, inputs, **self.map_kwargs
+        )
+        self.response_future = futures_list[0]
+
+    def cancel(self):
+        # cancelling will prevent any further retries, but won't affect any running tasks
+        self.cancelled = True
+
+    @property
+    def done(self):
+        return self.response_future.done
+
+    @property
+    def error(self):
+        return self.response_future.error
+
+    @property
+    def _exception(self):
+        return self.response_future._exception
+
+    @property
+    def stats(self):
+        return self.response_future.stats
+
+    def status(
+        self,
+        throw_except: bool = True,
+        internal_storage: Any = None,
+        check_only: bool = False,
+    ):
+        stat = self.response_future.status(
+            throw_except=throw_except,
+            internal_storage=internal_storage,
+            check_only=check_only,
+        )
+        if self.response_future.error:
+            reraise(*self.response_future._exception)
+        return stat
+
+    def result(self, throw_except: bool = True, internal_storage: Any = None):
+        res = self.response_future.result(
+            throw_except=throw_except, internal_storage=internal_storage
+        )
+        if self.response_future.error:
+            reraise(*self.response_future._exception)
+        return res
+
+
+class RetryingFunctionExecutor:
+    """
+    A wrapper around Lithops `FunctionExecutor` that supports retries.
+    """
+
+    def __init__(self, executor: FunctionExecutor):
+        self.executor = executor
+
+    def __enter__(self):
+        self.executor.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.executor.__exit__(exc_type, exc_value, traceback)
+
+    def map(
+        self,
+        map_function: Callable,
+        map_iterdata: List[Union[List[Any], Tuple[Any, ...], Dict[str, Any]]],
+        chunksize: Optional[int] = None,
+        extra_args: Optional[Union[List[Any], Tuple[Any, ...], Dict[str, Any]]] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+        runtime_memory: Optional[int] = None,
+        obj_chunk_size: Optional[int] = None,
+        obj_chunk_number: Optional[int] = None,
+        obj_newline: Optional[str] = '\n',
+        timeout: Optional[int] = None,
+        include_modules: Optional[List[str]] = [],
+        exclude_modules: Optional[List[str]] = [],
+        retries: Optional[int] = None,
+    ) -> List[RetryingFuture]:
+        futures_list = self.executor.map(
+            map_function,
+            map_iterdata,
+            chunksize=chunksize,
+            extra_args=extra_args,
+            extra_env=extra_env,
+            runtime_memory=runtime_memory,
+            obj_chunk_size=obj_chunk_size,
+            obj_chunk_number=obj_chunk_number,
+            obj_newline=obj_newline,
+            timeout=timeout,
+            include_modules=include_modules,
+            exclude_modules=exclude_modules,
+        )
+        return [
+            RetryingFuture(
+                f,
+                map_function=map_function,
+                input=i,
+                retries=retries,
+                chunksize=chunksize,
+                extra_args=extra_args,
+                extra_env=extra_env,
+                runtime_memory=runtime_memory,
+                obj_chunk_size=obj_chunk_size,
+                obj_chunk_number=obj_chunk_number,
+                obj_newline=obj_newline,
+                timeout=timeout,
+                include_modules=include_modules,
+                exclude_modules=exclude_modules,
+            )
+            for i, f in zip(map_iterdata, futures_list)
+        ]
+
+    def wait(
+        self,
+        fs: List[RetryingFuture],
+        throw_except: Optional[bool] = True,
+        return_when: Optional[Any] = ALL_COMPLETED,
+        download_results: Optional[bool] = False,
+        timeout: Optional[int] = None,
+        threadpool_size: Optional[int] = THREADPOOL_SIZE,
+        wait_dur_sec: Optional[int] = WAIT_DUR_SEC,
+        show_progressbar: Optional[bool] = True,
+    ) -> Tuple[List[RetryingFuture], List[RetryingFuture]]:
+        lookup = {f.response_future: f for f in fs}
+
+        while True:
+            response_futures = [f.response_future for f in fs]
+
+            done, pending = self.executor.wait(
+                response_futures,
+                throw_except=throw_except,
+                return_when=return_when,
+                download_results=download_results,
+                timeout=timeout,
+                threadpool_size=threadpool_size,
+                wait_dur_sec=wait_dur_sec,
+                show_progressbar=show_progressbar,
+            )
+
+            retrying_done = []
+            retrying_pending = [lookup[response_future] for response_future in pending]
+            for response_future in done:
+                retrying_future = lookup[response_future]
+                if response_future.error:
+                    retrying_future._inc_failure_count()
+                    if retrying_future._should_retry():
+                        retrying_future._retry(self.executor)
+                        # put back into pending since we are retrying this input
+                        retrying_pending.append(retrying_future)
+                        lookup[retrying_future.response_future] = retrying_future
+                    else:
+                        retrying_done.append(retrying_future)
+                else:
+                    retrying_done.append(retrying_future)
+
+            if return_when == ALWAYS:
+                break
+            elif return_when == ANY_COMPLETED and len(retrying_done) > 0:
+                break
+            elif return_when == ALL_COMPLETED and len(retrying_pending) == 0:
+                break
+
+        return retrying_done, retrying_pending

--- a/lithops/retries.py
+++ b/lithops/retries.py
@@ -14,7 +14,7 @@ from six import reraise
 
 class RetryingFuture:
     """
-    A wrapper around Lithops `ResponseFuture` that takes care of retries.
+    A wrapper around `ResponseFuture` that takes care of retries.
     """
 
     def __init__(
@@ -92,7 +92,7 @@ class RetryingFuture:
 
 class RetryingFunctionExecutor:
     """
-    A wrapper around Lithops `FunctionExecutor` that supports retries.
+    A wrapper around `FunctionExecutor` that supports retries.
     """
 
     def __init__(self, executor: FunctionExecutor):

--- a/lithops/tests/test_retries.py
+++ b/lithops/tests/test_retries.py
@@ -32,11 +32,13 @@ class TestRetries(unittest.TestCase):
         fexec = LocalhostExecutor()
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-            function = lambda x: deterministic_failure(tmp_path, timing_map, x)
+
+            def map_function(x):
+                return deterministic_failure(tmp_path, timing_map, x)
             input = range(n_tasks)
             with RetryingFunctionExecutor(fexec) as executor:
                 futures = executor.map(
-                    function,
+                    map_function,
                     input,
                     timeout=timeout,
                     retries=retries,

--- a/lithops/tests/test_retries.py
+++ b/lithops/tests/test_retries.py
@@ -1,0 +1,155 @@
+import time
+
+import pytest
+
+from lithops.executors import LocalhostExecutor
+from lithops.retries import RetryingFunctionExecutor
+
+
+def run_test(function, input, retries, timeout=10):
+    with RetryingFunctionExecutor(LocalhostExecutor()) as executor:
+        futures = executor.map(
+            function,
+            input,
+            timeout=timeout,
+            retries=retries,
+        )
+        done, pending = executor.wait(futures, throw_except=False)
+        assert len(pending) == 0
+    outputs = set(f.result() for f in done)
+    return outputs
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "timing_map, n_tasks, retries",
+    [
+        # no failures
+        ({}, 3, 2),
+        # first invocation fails
+        ({0: [-1], 1: [-1], 2: [-1]}, 3, 2),
+        # first two invocations fail
+        ({0: [-1, -1], 1: [-1, -1], 2: [-1, -1]}, 3, 2),
+        # first input sleeps once
+        ({0: [20]}, 3, 2),
+    ],
+)
+# fmt: on
+def test_success(tmp_path, timing_map, n_tasks, retries):
+    partial_map_function = lambda x: deterministic_failure(tmp_path, timing_map, x)
+    outputs = run_test(
+        function=partial_map_function,
+        input=range(n_tasks),
+        retries=retries,
+    )
+
+    assert outputs == set(range(n_tasks))
+
+    check_invocation_counts(tmp_path, timing_map, n_tasks, retries)
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "timing_map, n_tasks, retries",
+    [
+        # too many failures
+        ({0: [-1], 1: [-1], 2: [-1, -1, -1]}, 3, 2),
+    ],
+)
+# fmt: on
+def test_failure(tmp_path, timing_map, n_tasks, retries):
+    partial_map_function = lambda x: deterministic_failure(tmp_path, timing_map, x)
+    with pytest.raises(RuntimeError):
+        run_test(
+            function=partial_map_function,
+            input=range(n_tasks),
+            retries=retries,
+        )
+
+    check_invocation_counts(tmp_path, timing_map, n_tasks, retries)
+
+
+def read_int_from_file(path):
+    with open(path) as f:
+        return int(f.read())
+
+
+def write_int_to_file(path, i):
+    with open(path, "w") as f:
+        f.write(str(i))
+
+
+def deterministic_failure(path, timing_map, i):
+    """A function that can either run normally, run slowly, or raise
+    an exception, depending on input and invocation count.
+
+    The timing_map is a dictionary whose keys are inputs and values
+    are sequences of timing information for each invocation.
+    The maginitude of the value is the time to sleep in seconds, and
+    the sign indicates the input is returned normally (positive, or 0),
+    or an exception is raised (negative).
+
+    If a input is missing then all invocations will run normally.
+
+    If there are subsequent invocations to the ones in the sequence, then
+    they will all run normally.
+    """
+    # increment number of invocations of this function with arg i
+    invocation_count_file = path / str(i)
+    if invocation_count_file.exists():
+        invocation_count = read_int_from_file(invocation_count_file)
+    else:
+        invocation_count = 0
+    write_int_to_file(invocation_count_file, invocation_count + 1)
+
+    timing_code = 0
+    if i in timing_map:
+        timing_codes = timing_map[i]
+        if invocation_count >= len(timing_codes):
+            timing_code = 0
+        else:
+            timing_code = timing_codes[invocation_count]
+
+    if timing_code >= 0:
+        time.sleep(timing_code)
+        return i
+    else:
+        time.sleep(-timing_code)
+        raise RuntimeError(
+            f"Deliberately fail on invocation number {invocation_count+1} for input {i}"
+        )
+
+
+def check_invocation_counts(
+    path, timing_map, n_tasks, retries=None, expected_invocation_counts_overrides=None
+):
+    expected_invocation_counts = {}
+    for i in range(n_tasks):
+        if i not in timing_map:
+            expected_invocation_counts[i] = 1
+        else:
+            timing_codes = timing_map[i]
+            expected_invocation_count = len(timing_codes) + 1
+
+            if retries is not None:
+                # there shouldn't have been more than retries + 1 invocations
+                max_invocations = retries + 1
+                expected_invocation_count = min(
+                    expected_invocation_count, max_invocations
+                )
+
+            expected_invocation_counts[i] = expected_invocation_count
+
+    if expected_invocation_counts_overrides is not None:
+        expected_invocation_counts.update(expected_invocation_counts_overrides)
+
+    actual_invocation_counts = {i: read_int_from_file(path / str(i)) for i in range(n_tasks)}
+
+    if actual_invocation_counts != expected_invocation_counts:
+        for i, expected_count in expected_invocation_counts.items():
+            actual_count = actual_invocation_counts[i]
+            if actual_count != expected_count:
+                print(
+                    f"Invocation count for {i}, expected: {expected_count}, actual: {actual_count}"
+                )
+    assert actual_invocation_counts == expected_invocation_counts


### PR DESCRIPTION
Fixes #1289

This is a first draft - it still needs API doc and tests.

As noted in #1289 this uses wrappers around `ResponseFuture` and `FunctionExecutor`. I considered using subclasses, but that wasn't possible for `ResponseFuture` because `RetryingFuture` updates the underlying `ResponseFuture` for each retry. And `FunctionExecutor` already has subclasses (`LocalhostExecutor`, `ServerlessExecutor`, and `StandaloneExecutor`), so that wasn't possible either.

It might be possible to add the retry logic directly into the existing `ResponseFuture` and `FunctionExecutor` classes, but I'm not familiar enough with the internals, so I wasn't sure how easy that would be or if it's even desirable. @JosepSampe what do you think?

The current implementation in this PR also lacks some of the methods that `FunctionExecutor` has: `call_async`, `map_reduce`, and `get_result`. It would be possible to add these (probably later), but I haven't needed them so I haven't spent any time looking at what's needed.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

