### PR TITLE
Fix serialization bug which triggers side effects on dynamic attributes

### DIFF
--- a/lithops/job/serialize.py
+++ b/lithops/job/serialize.py
@@ -132,7 +132,7 @@ class SerializeIndependent:
             worklist.append(obj)
 
         elif type(obj).__name__ == 'cython_function_or_method':
-            for k, v in inspect.getmembers(obj):
+            for k, v in inspect.getmembers_static(obj):
                 if k == '__globals__':
                     mods.add(v['__file__'])
 
@@ -146,13 +146,13 @@ class SerializeIndependent:
                     worklist.append(param)
                 else:
                     # it is a user defined class
-                    for k, v in inspect.getmembers(param):
+                    for k, v in inspect.getmembers_static(param):
                         if inspect.isfunction(v) or (inspect.ismethod(v) and inspect.isfunction(v.__func__)):
                             worklist.append(v)
         else:
             # The obj is the user's function but in form of a class
             found_methods = []
-            for k, v in inspect.getmembers(obj):
+            for k, v in inspect.getmembers_static(obj):
                 if inspect.isfunction(v) or (inspect.ismethod(v) and inspect.isfunction(v.__func__)):
                     found_methods.append(k)
                     worklist.append(v)

--- a/lithops/tests/functions.py
+++ b/lithops/tests/functions.py
@@ -144,3 +144,16 @@ def my_map_function_storage(key_i, bucket_name, storage):
             else:
                 counter[word] += 1
     return counter
+
+
+class SideEffect:
+    def __init__(self):
+        pass
+
+    @property
+    def foo(self):
+        raise RuntimeError("Side effect triggered")
+
+
+def passthrough_function(x):
+    return x

--- a/lithops/tests/test_call_async.py
+++ b/lithops/tests/test_call_async.py
@@ -17,7 +17,7 @@
 import pytest
 import lithops
 import logging
-from lithops.tests.functions import simple_map_function
+from lithops.tests.functions import simple_map_function, SideEffect, passthrough_function
 
 logger = logging.getLogger(__name__)
 
@@ -50,3 +50,11 @@ class TestAsync:
         fexec.call_async(simple_map_function, {'x': 2, 'y': 8})
         result = fexec.get_result()
         assert result == 10
+
+    def test_call_async_object_with_side_effects(self):
+        """Test that passing an object with properties that trigger side effects does not cause the side effects to be triggered."""
+            
+        se = SideEffect()
+        fexec = lithops.FunctionExecutor(config=pytest.lithops_config)
+        fexec.call_async(passthrough_function, se)
+        result = fexec.get_result()


### PR DESCRIPTION
Thanks for this great open source library! 🙏  I'm deeply appreciative of your work for the community.

In using lithops, I discovered a bug in the serialization routines which triggers side effects on dynamic attributes (e.g. `@property` methods). For me this, is a dealbreaker for using lithops with [Arraylake](https://docs.earthmover.io/), since our objects have such properties which trigger expensive API calls. For example, in a map job over 1000 objects, this method gets called 1000 times before the function is even submitted.

I chased this down to the use of `inspect.getmembers` in `lithops.job.serialize`. 

https://github.com/lithops-cloud/lithops/blob/cdf558448608d48a0eb0ad1fe02113495b25173f/lithops/job/serialize.py#L135

Python 3.11 implements [`inspect.getmembers_static`](https://docs.python.org/3/library/inspect.html#inspect.getmembers_static), which is designed to address this exact situation. (See also discussion in https://github.com/python/cpython/pull/20911.)

To demonstrate this, this PR includes a test for this situation and implements a fix using `getmembers_static`. This passes in a local environment with python 3.11. However, it will fail in CI, which uses python 3.10.

I would recommend vendoring a version of this function until you drop python 3.10 support.

---
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

