### PR TITLE
[Jobrunner] deprectate distutils

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -13,8 +13,9 @@ on:
 jobs:
 
   localhost_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 

--- a/lithops/libs/multyvac/module_dependency.py
+++ b/lithops/libs/multyvac/module_dependency.py
@@ -116,7 +116,8 @@ class ModuleDependencyAnalyzer:
         # logger.debug('Inspecting module %r', root_module_name)
         try:
             fp, pathname, description = imp.find_module(root_module_name)
-            logger.debug(f"Module '{root_module_name}' found in {pathname}")
+            if pathname:
+                logger.debug(f"Module '{root_module_name}' found in {pathname}")
         except ImportError:
             logger.debug('Could not find module %r, skipping', root_module_name)
             return

--- a/lithops/worker/jobrunner.py
+++ b/lithops/worker/jobrunner.py
@@ -26,7 +26,6 @@ import inspect
 import requests
 import traceback
 from pydoc import locate
-from distutils.util import strtobool
 
 from lithops.worker.utils import peak_memory
 
@@ -210,7 +209,7 @@ class JobRunner:
             func = pickle.loads(self.job.func)
             data = pickle.loads(self.job.data)
 
-            if strtobool(os.environ.get('__LITHOPS_REDUCE_JOB', 'False')):
+            if eval(os.environ.get('__LITHOPS_REDUCE_JOB', 'False')):
                 self._wait_futures(data)
             elif is_object_processing_function(func):
                 self._load_object(data)

--- a/lithops/worker/status.py
+++ b/lithops/worker/status.py
@@ -4,7 +4,6 @@ import json
 import time
 import logging
 from tblib import pickling_support
-from distutils.util import strtobool
 from contextlib import contextmanager
 
 import lithops.worker
@@ -45,7 +44,7 @@ class CallStatus:
             'chunksize': job.chunksize
         }
 
-        if strtobool(os.environ.get('WARM_CONTAINER', 'False')):
+        if eval(os.environ.get('WARM_CONTAINER', 'False')):
             self.status['worker_cold_start'] = False
         else:
             self.status['worker_cold_start'] = True


### PR DESCRIPTION
`distutils` library is deprecated on python 3.12
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

