### PR TITLE
Move boto3 package into `lithops[aws]` extra

### DIFF
--- a/docs/source/compute_config/aws_batch.md
+++ b/docs/source/compute_config/aws_batch.md
@@ -2,6 +2,14 @@
 
 Lithops with *AWS Batch* as serverless batch compute backend.
 
+## Installation
+
+1. Install AWS backend dependencies:
+
+```bash
+python3 -m install lithops[aws]
+```
+
 ## Configuration
 
 1. [Login](https://console.aws.amazon.com/?nc2=h_m_mc) to Amazon Web Services Console (or signup if you don't have an account)

--- a/docs/source/compute_config/aws_ec2.md
+++ b/docs/source/compute_config/aws_ec2.md
@@ -12,6 +12,14 @@ Any Virtual Machine (VM) need to define the instance’s operating system and ve
 
 - Option 2: Alternatively, you can use a pre-built custom image that will greatly improve VM creation time for Lithops jobs. To benefit from this approach, navigate to [runtime/aws_ec2](https://github.com/lithops-cloud/lithops/tree/master/runtime/aws_ec2), and follow the instructions.
 
+## Installation
+
+1. Install AWS backend dependencies:
+
+```bash
+python3 -m install lithops[aws]
+```
+
 ## Lithops Consume mode
 
 In this mode, Lithops can start and stop an existing VM, and deploy an entire job to that VM. The partition logic in this scenario is different from the `create/reuse` modes, since the entire job is executed in the same VM.

--- a/docs/source/compute_config/aws_lambda.md
+++ b/docs/source/compute_config/aws_lambda.md
@@ -2,6 +2,14 @@
 
 Lithops with *AWS Lambda* as serverless compute backend.
 
+## Installation
+
+1. Install AWS backend dependencies:
+
+```bash
+python3 -m install lithops[aws]
+```
+
 ## Configuration
 
 1. [Login](https://console.aws.amazon.com/?nc2=h_m_mc) to Amazon Web Services Console (or signup if you don't have an account)

--- a/docs/source/storage_config/aws_s3.md
+++ b/docs/source/storage_config/aws_s3.md
@@ -2,6 +2,14 @@
 
 Lithops with AWS S3 as storage backend.
 
+## Installation
+
+1. Install AWS backend dependencies:
+
+```bash
+python3 -m install lithops[aws]
+```
+
 ## Configuration
 
 Lithops automatically creates a bucket with a unique name for your user. If you want to use a different bucket, you can create it manually and provide the name in the lithops config file. For this:

--- a/docs/source/storage_config/ceph.md
+++ b/docs/source/storage_config/ceph.md
@@ -5,11 +5,17 @@ Lithops with Ceph storage backend.
 
 ## Installation
 
-1. Install Ceph.
+1. Install Ceph backend dependencies:
 
-2. Create a new user.
+```bash
+python3 -m install lithops[ceph]
+```
 
-3. Create a new bucket (e.g. `lithops-data`). Remember to update the corresponding Lithops config field with this bucket name.
+2. Install Ceph.
+
+3. Create a new user.
+
+4. Create a new bucket (e.g. `lithops-data`). Remember to update the corresponding Lithops config field with this bucket name.
 
 ## Configuration
 

--- a/docs/source/storage_config/minio.md
+++ b/docs/source/storage_config/minio.md
@@ -5,11 +5,17 @@ Lithops with MinIO storage backend.
 
 ## Installation
 
-1. Install MinIO.
+1. Install MinIO backend dependencies:
 
-2. Create a new user.
+```bash
+python3 -m install lithops[minio]
+```
 
-3. Create a new bucket (e.g. `lithops-data`). Remember to update the corresponding Lithops config field with this bucket name.
+2. Install MinIO.
+
+3. Create a new user.
+
+4. Create a new bucket (e.g. `lithops-data`). Remember to update the corresponding Lithops config field with this bucket name.
 
 ## Configuration
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ extras_require = {
         'azure-storage-blob',
         'azure-storage-queue'
     ],
+    'minio': [
+        'boto3'
+    ],
     'multiprocessing': [
         'pynng'
     ],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ install_requires = [
     'tqdm',
     'tblib',
     'docker',
-    'boto3',
     'requests',
     'seaborn',
     'paramiko',
@@ -41,6 +40,9 @@ extras_require = {
     'aliyun': [
         'aliyun-fc2',
         'oss2'
+    ],
+    'aws': [
+        'boto3'
     ],
     'azure': [
         'azure-mgmt-resource',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ extras_require = {
         'azure-storage-blob',
         'azure-storage-queue'
     ],
+    'ceph': [
+        'boto3'
+    ],
     'minio': [
         'boto3'
     ],


### PR DESCRIPTION
The `boto3` package is not needed unless you're using AWS, so this moves it from the base installation to an extra package, installable using `pip install lithops[aws]`. This is inline with GCP and Azure, for example.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

