### PR TITLE
Fix typo (knative -> cloudrun) in custom GCP Cloud Run runtime docs

### DIFF
--- a/runtime/gcp_cloudrun/README.md
+++ b/runtime/gcp_cloudrun/README.md
@@ -93,8 +93,8 @@ gcp_cloudrun:
     ENV APP_HOME /lithops
     WORKDIR $APP_HOME
     
-    COPY lithops_knative.zip .
-    RUN unzip lithops_knative.zip && rm lithops_knative.zip
+    COPY lithops_cloudrun.zip .
+    RUN unzip lithops_cloudrun.zip && rm lithops_cloudrun.zip
     
     CMD exec gunicorn --bind :$PORT lithopsproxy:proxy
     ```


### PR DESCRIPTION
👋 All, thanks for the amazing project! I'm really enjoying getting to know it.

I was looking into making my own custom runtime for use with GCP Cloud Run and noticed this small typo in the docs, hopefully the fix is welcome and correct!

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

