### PR TITLE
[k8s] Add configurable master pod timeout to Kubernetes backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - [Singularity] Added new singularity compute backend
 - [Oracle Functions] Added support for python 3.11
+- [k8s] Added 'master_timeout' parameter to k8s backend
 
 ### Changed
 - 

--- a/docs/source/compute_config/kubernetes.md
+++ b/docs/source/compute_config/kubernetes.md
@@ -75,6 +75,7 @@ k8s:
 |k8s | runtime_cpu | 1 |no | CPU limit. Default 1vCPU |
 |k8s | runtime_memory | 512 |no | Memory limit in MB. Default 512MB |
 |k8s | runtime_timeout | 600 |no | Runtime timeout in seconds. Default 600 seconds |
+|k8s | master_timeout | 600 |no | Master pod timeout in seconds. Default 600 seconds |
 
 ## Test Lithops
 

--- a/lithops/serverless/backends/k8s/config.py
+++ b/lithops/serverless/backends/k8s/config.py
@@ -18,6 +18,7 @@ import os
 
 DEFAULT_CONFIG_KEYS = {
     'runtime_timeout': 600,  # Default: 10 minutes
+    'master_timeout': 600,  # Default: 10 minutes
     'runtime_memory': 512,  # Default memory: 512 MB
     'runtime_cpu': 1,  # 1 vCPU
     'max_workers': 100,

--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -452,6 +452,7 @@ class KubernetesBackend:
         master_res['metadata']['namespace'] = self.namespace
         master_res['metadata']['labels']['version'] = 'lithops_v' + __version__
         master_res['metadata']['labels']['user'] = self.user
+        master_res['spec']['activeDeadlineSeconds'] = self.k8s_config['master_timeout']
 
         container = master_res['spec']['template']['spec']['containers'][0]
         container['image'] = docker_image_name


### PR DESCRIPTION
This pull request introduces a new configurable parameter, `master_timeout`, to the Kubernetes backend.

### Motivation

There may be jobs that last more than 10 minutes, which is the default master pod duration. Although the master pod is expected to restart automatically, there are cases where it does not restart or after restarting some jobs are lost, resulting in jobs shown in Lithops logs as **Pending**.

The new `master_timeout` parameter mitigates these issues by allowing to configure a suitable timeout based on the job requirements.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

