### PR TITLE
Fix unintended failure of `if self._call_output` in future.py for objects with ambiguous truth values

### DIFF
--- a/lithops/future.py
+++ b/lithops/future.py
@@ -288,7 +288,7 @@ class ResponseFuture:
                 f'from call {self.call_id} - Activation ID: {self.activation_id}'
             )
 
-        if self._call_output or not self._produce_output:
+        if self._call_output is not None or not self._produce_output:
             self._set_state(ResponseFuture.State.Done)
         else:
             self._set_state(ResponseFuture.State.Success)

--- a/lithops/tests/test_future.py
+++ b/lithops/tests/test_future.py
@@ -1,0 +1,27 @@
+import pytest
+
+import lithops
+
+
+class HasAmbiguousTruthValue:
+    """An object with an ambiguous truth value, simulates pandas.DataFrame and numpy.NDArray."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def __bool__(self):
+        raise ValueError(
+            f"The truth value of a {type(self).__name__} is ambiguous. "
+            "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+        )
+
+
+def test_fn_returns_obj_with_ambiguous_truth_value():
+    def returns_obj_with_ambiguous_truth_value(param):
+        return HasAmbiguousTruthValue(param)
+
+    fexec = lithops.FunctionExecutor(config=pytest.lithops_config)
+    future = fexec.call_async(returns_obj_with_ambiguous_truth_value, "Hello World!")
+    result = future.result()
+    assert result.data == "Hello World!"
+

--- a/lithops/tests/test_future.py
+++ b/lithops/tests/test_future.py
@@ -24,4 +24,3 @@ def test_fn_returns_obj_with_ambiguous_truth_value():
     future = fexec.call_async(returns_obj_with_ambiguous_truth_value, "Hello World!")
     result = future.result()
     assert result.data == "Hello World!"
-


### PR DESCRIPTION
Closes https://github.com/lithops-cloud/lithops/issues/1396

As described in #1396, in `future.py`, the check `if self._call_output` fails (unintentionally) if the object assigned to `self._call_output` has an ambiguous truth value, as is the case for [pandas dataframes](https://github.com/pandas-dev/pandas/blob/e78ebd3f845c086af1d71c0604701ec49df97228/pandas/core/generic.py#L1494-L1499) and [numpy ndarrays](https://numpy.org/doc/stable/reference/arrays.ndarray.html#:~:text=Truth%2Dvalue%20testing%20of%20an%20array%20invokes%20ndarray.__bool__%2C%20which%20raises%20an%20error%20if%20the%20number%20of%20elements%20in%20the%20array%20is%20larger%20than%201%2C%20because%20the%20truth%20value%20of%20such%20arrays%20is%20ambiguous).

Changing this check to `if self._call_output is not None` fixes this unintended failure. The added test checks for this behavior with a custom object, to avoid taking a pandas and/or numpy dependency in the test environment.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

