### PR TITLE
Fix race condition in RMQ Monitor

### DIFF
--- a/lithops/monitor.py
+++ b/lithops/monitor.py
@@ -169,6 +169,7 @@ class RabbitmqMonitor(Monitor):
 
         self.rabbit_amqp_url = config.get('amqp_url')
         self.queue = f'lithops-{self.executor_id}'
+        self.tag = None
         self._create_resources()
 
     def _create_resources(self):
@@ -189,6 +190,8 @@ class RabbitmqMonitor(Monitor):
         """
         connection = pika.BlockingConnection(self.pikaparams)
         channel = connection.channel()
+        if self.tag:
+            channel.basic_cancel(self.tag)
         channel.queue_delete(queue=self.queue)
         channel.close()
         connection.close()
@@ -241,9 +244,7 @@ class RabbitmqMonitor(Monitor):
                 self.token_bucket_q.put('#')
 
     def run(self):
-        logger.debug(f'ExecutorID {self.executor_id} |  Starting RabbitMQ job monitor')
-        prevoius_log = None
-        log_time = 0
+        logger.debug(f'ExecutorID {self.executor_id} | Starting RabbitMQ job monitor')
         SLEEP_TIME = 2
 
         channel = self.connection.channel()
@@ -261,21 +262,24 @@ class RabbitmqMonitor(Monitor):
             if self._all_ready() or not self.should_run:
                 ch.stop_consuming()
                 ch.close()
-                self._print_status_log()
-                logger.debug(f'ExecutorID {self.executor_id} | RabbitMQ job monitor finished')
 
-        channel.basic_consume(self.queue, callback, auto_ack=True)
-        threading.Thread(target=channel.start_consuming, daemon=True).start()
+        def manage_timeouts():
+            prevoius_log = None
+            log_time = 0
+            while self.should_run and not self._all_ready():
+                # Format call_ids running, pending and done
+                prevoius_log, log_time = self._print_status_log(previous_log=prevoius_log, log_time=log_time)
+                self._future_timeout_checker(self.futures)
+                time.sleep(SLEEP_TIME)
+                log_time += SLEEP_TIME
 
-        while not self._all_ready():
-            # Format call_ids running, pending and done
-            prevoius_log, log_time = self._print_status_log(previous_log=prevoius_log, log_time=log_time)
-            self._future_timeout_checker(self.futures)
-            time.sleep(SLEEP_TIME)
-            log_time += SLEEP_TIME
+        threading.Thread(target=manage_timeouts, daemon=True).start()
 
-            if not self.should_run:
-                break
+        self.tag = channel.basic_consume(self.queue, callback, auto_ack=True)
+        channel.start_consuming()
+        self.tag = None
+        self._print_status_log()
+        logger.debug(f'ExecutorID {self.executor_id} | RabbitMQ job monitor finished')
 
 
 class StorageMonitor(Monitor):


### PR DESCRIPTION
This PR fixes a race condition in the RabbitMQ job monitor.

The Rabbit Monitor has a main thread, which is left in a loop logging the status and checking future timeouts with 2 second sleeps, and a daemon thread consuming from Rabbit.

If the consumer thread  finds all futures completed after processing a message, it will stop  consuming. However, the main thread may still be in a 2 second sleep, which creates a window for the executor to add more futures to monitor (the executor checks the state of the main thread). Just that the consumer thread has already stopped, so those futures will stay pending indefinitely. This can easily happen in a map_reduce call when all map functions end closely together.

This PR basically flips the threads' responsibilities. The main Monitor thread is the one consuming, while the daemon is in the sleep loop. This way, when the Rabbit consumer stops, the Monitor is in stopped state immediately and the executor would create a new monitor if more futures should be waited. It is fine to leave the sleep loop thread running in the background until the next loop.


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

