### PR TITLE
[K8s] Fix default runtime build broken by Debian Buster EOL

### DIFF
--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -169,10 +169,10 @@ class KubernetesBackend:
         """
         Builds the default runtime
         """
-        # Build default runtime using local dokcer
-        dockerfile = "Dockefile.default-k8s-runtime"
+        # Build default runtime using local docker
+        dockerfile = "Dockerfile.default-k8s-runtime"
         with open(dockerfile, 'w') as f:
-            f.write(f"FROM python:{utils.CURRENT_PY_VERSION}-slim-buster\n")
+            f.write(f"FROM python:{utils.CURRENT_PY_VERSION}-slim-bookworm\n")
             f.write(config.DOCKERFILE_DEFAULT)
         try:
             self.build_runtime(docker_image_name, dockerfile)

--- a/runtime/kubernetes/Dockerfile
+++ b/runtime/kubernetes/Dockerfile
@@ -1,17 +1,17 @@
-# Python 3.6
-#FROM python:3.6-slim-buster
-
-# Python 3.7
-#FROM python:3.7-slim-buster
-
 # Python 3.8
-#FROM python:3.8-slim-buster
+#FROM python:3.8-slim-bookworm
 
 # Python 3.9
-#FROM python:3.9-slim-buster
+#FROM python:3.9-slim-bookworm
 
 # Python 3.10
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bookworm
+
+# Python 3.11
+#FROM python:3.11-slim-bookworm
+
+# Python 3.12
+#FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y \
         zip redis-server curl \


### PR DESCRIPTION
## Problem                                                                                                                                                           
                  
The default k8s runtime build (`lithops/serverless/backends/k8s/k8s.py:175` and `runtime/kubernetes/Dockerfile`) bases on `python:*-slim-buster`. Debian 10 (Buster) reached EOL in June 2024 and its APT repos moved to archive, so the generated `RUN apt-get update` fails with 404s and the build aborts. Every new k8s user following the documented "default runtime is built the first time you execute a function" flow hits this.                                                                     
                  
## Fix
- slim-buster -> slim-bookworm (Debian 12, supported until 2028) in both places.                                                                                  
- Bundled Dockerfile: drop EOL Python 3.6 / 3.7 variants (no `slim-bookworm` tag published), add 3.11 / 3.12.
- Drive-by: typo `Dockefile.default-k8s-runtime` → `Dockerfile.default-k8s-runtime`.   
 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

