### PR TITLE
[Docs] Fix config template MinIO/Ceph keys and remove dead k8s image …

### DIFF
--- a/config/config_template.yaml
+++ b/config/config_template.yaml
@@ -165,14 +165,14 @@
 #ceph:
     #storage_bucket: <BUCKET_NAME>
     #endpoint: <ENDPOINT_URL>
-    #access_key: <ACCESS_KEY>
-    #secret_key: <ACCESS_KEY>
-    
+    #access_key_id: <ACCESS_KEY_ID>
+    #secret_access_key: <SECRET_ACCESS_KEY>
+
 #minio:
     #storage_bucket: <BUCKET_NAME>
     #endpoint: <ENDPOINT_URL>
-    #access_key: <ACCESS_KEY>
-    #secret_key: <ACCESS_KEY>
+    #access_key_id: <ACCESS_KEY_ID>
+    #secret_access_key: <SECRET_ACCESS_KEY>
     
 #redis:
     #host: <ENDPOINT_URL>

--- a/runtime/kubernetes/README.md
+++ b/runtime/kubernetes/README.md
@@ -57,29 +57,17 @@ k8s:
 
 2. **Use an already built runtime from a public repository**
 
-    Maybe someone already built a Docker image with all the packages you need, and put it in a public repository.
-    In this case, you can use that Docker image and avoid the building process by simply specifying the image name when creating a new executor, for example:
+    If someone has already built a Docker image with the packages you need and pushed it to a public registry, you can avoid the build step entirely and reference that image when creating a new executor, for example:
 
     ```python
     import lithops
-    fexec = lithops.FunctionExecutor(runtime='docker.io/lithopscloud/lithops-k8s-conda-v312:01')
+    fexec = lithops.FunctionExecutor(runtime='docker.io/<docker_username>/<runtime_name>:<tag>')
     ```
 
-    Alternatively, you can create a Lithops runtime based on already built Docker image by executing the following command, which will deploy all the necessary information to use the runtime with your Lithops.
+    Alternatively, you can pre-register a Lithops runtime from an already built Docker image with:
 
     ```
-    $ lithops runtime deploy -b k8s docker_username/runtimename:tag
-    ```
-
-    For example, you can use an already buit runtime based on Python 3.12 and with the *matplotlib* and *nltk* libraries by running:
-
-    ```
-    $ lithops runtime deploy -b k8s docker.io/lithopscloud/lithops-k8s-matplotlib-v312:01
-    ```
-
-    ```python
-    import lithops
-    fexec = lithops.FunctionExecutor(runtime='docker.io/lithopscloud/lithops-k8s-matplotlib:v312:01')
+    $ lithops runtime deploy -b k8s <docker_username>/<runtime_name>:<tag>
     ```
 
 3. **Clean everything**


### PR DESCRIPTION
## Problem                                                                                                                                                                   
                                                                                                                                                                             
Two small but misleading bugs in the docs surface:                                                                                                                           
   
1. **`config/config_template.yaml`** — the `minio` and `ceph` sections list keys `access_key` / `secret_key`, but `lithops/storage/backends/minio/config.py:18` and `lithops/storage/backends/ceph/config.py:18` both require `access_key_id` / `secret_access_key`. Anyone copying the template gets `'access_key_id' is mandatory under '<backend>' section` at startup.                                                                                                                                             
                                                                                                                                                                             
2. **`runtime/kubernetes/README.md`** — points users to example images on Docker Hub that do not exist:                                                                    
     - `docker.io/lithopscloud/lithops-k8s-conda-v312:01`                                                                                                                      
     - `docker.io/lithopscloud/lithops-k8s-matplotlib-v312:01`                                                                                                                 
     - `docker.io/lithopscloud/lithops-k8s-matplotlib:v312:01` (also has a stray second colon — invalid tag)                                                                   
                                                                                                                                                                               
The `lithopscloud` namespace currently only publishes `ibmcf-python-*` and `openwhisk-python-*` images. A user trying these examples gets `manifest unknown` from the registry.                                                                                                                                                                    
                                                                                                                                                                             
## Fix                                                                                                                                                                                                                                                                                                                                                
  - Update both sections of `config_template.yaml` to use the keys the code actually requires.                                                                                 
  - Replace the broken `lithopscloud/lithops-k8s-*` examples with generic placeholders (`<docker_username>/<runtime_name>:<tag>`) so the README documents the *shape* of a     
  valid value without asserting that a particular image exists. Also drops the misleading "buit" typo and the doubly-colonned variant.                                         
                                                                                                                                          

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

