### PR TITLE
[K8s] Make pod and container securityContext configurable (closes #1432)

### DIFF
--- a/docs/source/compute_config/kubernetes.md
+++ b/docs/source/compute_config/kubernetes.md
@@ -76,6 +76,33 @@ k8s:
 |k8s | runtime_memory | 512 |no | Memory limit in MB. Default 512MB |
 |k8s | runtime_timeout | 600 |no | Runtime timeout in seconds. Default 600 seconds |
 |k8s | master_timeout | 600 |no | Master pod timeout in seconds. Default 600 seconds |
+|k8s | container_security_context | PSS Baseline (drop ALL caps, no privilege escalation, RuntimeDefault seccomp) | no | Mapping injected as the container `securityContext` on every Lithops pod. Set to `null` to disable. |
+|k8s | pod_security_context | | no | Mapping injected as the pod-level `securityContext`. Required for clusters enforcing Pod Security Standards Restricted (e.g. EGI Rancher, GKE Autopilot, OpenShift). Requires a non-root runtime image. |
+
+## Running on Pod Security Standards Restricted clusters
+
+Clusters enforcing the [Pod Security Standards "Restricted"](https://kubernetes.io/docs/concepts/security/pod-security-standards/) profile (Rancher with EGI policies, GKE Autopilot, OpenShift, AKS with Azure Policy, EKS with admission controllers) require pods to run as a non-root user with additional hardening. Set `pod_security_context` and use a runtime image that has a non-root `USER` directive:
+
+```yaml
+k8s:
+    runtime: <your_user>/<non_root_runtime>:<tag>
+    pod_security_context:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+            type: RuntimeDefault
+    container_security_context:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+            drop: ["ALL"]
+        seccompProfile:
+            type: RuntimeDefault
+```
+
+Providing `container_security_context` fully replaces the defaults — copy the snippet above and adjust if you want to extend rather than override.
 
 ## Test Lithops
 

--- a/lithops/serverless/backends/k8s/config.py
+++ b/lithops/serverless/backends/k8s/config.py
@@ -26,6 +26,14 @@ DEFAULT_CONFIG_KEYS = {
     'docker_server': 'docker.io'
 }
 
+# Pod Security Standards "Baseline"-aligned container defaults; safe to
+# enable without runtime image changes. Override via `container_security_context`.
+DEFAULT_CONTAINER_SECURITY_CONTEXT = {
+    'allowPrivilegeEscalation': False,
+    'capabilities': {'drop': ['ALL']},
+    'seccompProfile': {'type': 'RuntimeDefault'},
+}
+
 DEFAULT_GROUP = "batch"
 DEFAULT_VERSION = "v1"
 MASTER_NAME = "lithops-master"
@@ -141,6 +149,15 @@ def load_config(config_data):
     for key in DEFAULT_CONFIG_KEYS:
         if key not in config_data['k8s']:
             config_data['k8s'][key] = DEFAULT_CONFIG_KEYS[key]
+
+    if 'container_security_context' not in config_data['k8s']:
+        config_data['k8s']['container_security_context'] = DEFAULT_CONTAINER_SECURITY_CONTEXT
+    config_data['k8s'].setdefault('pod_security_context', None)
+
+    for key in ('container_security_context', 'pod_security_context'):
+        value = config_data['k8s'][key]
+        if value is not None and not isinstance(value, dict):
+            raise Exception(f"'{key}' under 'k8s' must be a mapping or null, got {type(value).__name__}")
 
     if 'runtime' in config_data['k8s']:
         runtime = config_data['k8s']['runtime']

--- a/lithops/serverless/backends/k8s/k8s.py
+++ b/lithops/serverless/backends/k8s/k8s.py
@@ -125,6 +125,16 @@ class KubernetesBackend:
             self.name, self.k8s_config, 'lithops-kubernetes-default'
         )
 
+    def _apply_security_context(self, job_res):
+        """Inject pod- and container-level securityContext from config (if any)."""
+        pod_spec = job_res['spec']['template']['spec']
+        pod_sc = self.k8s_config.get('pod_security_context')
+        if pod_sc:
+            pod_spec['securityContext'] = pod_sc
+        container_sc = self.k8s_config.get('container_security_context')
+        if container_sc:
+            pod_spec['containers'][0]['securityContext'] = container_sc
+
     def build_runtime(self, docker_image_name, dockerfile, extra_args=[]):
         """
         Builds a new runtime from a Docker file and pushes it to the registry
@@ -458,6 +468,8 @@ class KubernetesBackend:
         master_res['metadata']['labels']['user'] = self.user
         master_res['spec']['activeDeadlineSeconds'] = self.k8s_config['master_timeout']
 
+        self._apply_security_context(master_res)
+
         container = master_res['spec']['template']['spec']['containers'][0]
         container['image'] = docker_image_name
         container['env'][0]['value'] = 'run_master'
@@ -648,6 +660,8 @@ class KubernetesBackend:
             job_res['spec']['activeDeadlineSeconds'] = self.k8s_config['runtime_timeout']
             job_res['spec']['parallelism'] = total_workers
 
+            self._apply_security_context(job_res)
+
             container = job_res['spec']['template']['spec']['containers'][0]
             container['image'] = docker_image_name
             if not docker_image_name.endswith(':latest'):
@@ -693,6 +707,8 @@ class KubernetesBackend:
         job_res['metadata']['namespace'] = self.namespace
         job_res['metadata']['labels']['version'] = 'lithops_v' + __version__
         job_res['metadata']['labels']['user'] = self.user
+
+        self._apply_security_context(job_res)
 
         container = job_res['spec']['template']['spec']['containers'][0]
         container['image'] = docker_image_name


### PR DESCRIPTION
Closes #1432.

Two new optional config keys under `k8s`:                                                                                                                                                                       
   
| Key | Default | Notes |                                                                                                                                                                                       
|---|---|---|   
| `container_security_context` | PSS Baseline (drop ALL caps, no privesc, RuntimeDefault seccomp) | Applied to every Lithops pod (master, worker, metadata) |
| `pod_security_context` | `null` | Opt-in; needed for PSS Restricted clusters (EGI Rancher, GKE Autopilot, OpenShift, …). Requires a non-root runtime image. |                                                 
                                                                                                                                                                                                                  
User-provided values fully replace defaults (no merge), per docs.                                                                                                                                               
                                                                                                                                                                                                                                
The constraint @aicardi-obspm hit isn't Rancher-specific, it's upstream [Pod Security Standards "Restricted"](https://kubernetes.io/docs/concepts/security/pod-security-standards/), enforced by GKE Autopilot, OpenShift, EKS with admission, etc. A generic raw-dict config covers all of them without growing a vendor-named enum, and ships secure-by-default for the parts that don't require image cooperation. 

Discussed under #1432.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

